### PR TITLE
Replace support email with help@octolane.com

### DIFF
--- a/.mintlify/Assistant.md
+++ b/.mintlify/Assistant.md
@@ -20,5 +20,5 @@ You are the Octolane AI assistant - a helpful guide for Octolane's self-driving 
 - Use "Signal" (capitalized) when referring to the website visitor identification feature.
 
 ## Support
-- For questions you can't answer, direct users to support@octolane.com or the founder directly at one@octolane.com.
+- For questions you can't answer, direct users to help@octolane.com or the founder directly at one@octolane.com.
 - For billing questions, direct users to Settings > Billing in the Octolane dashboard.

--- a/integrations.mdx
+++ b/integrations.mdx
@@ -21,6 +21,6 @@ Octolane stays self-driving by tapping into Gmail and Google Calendar with least
 </AccordionGroup>
 
 <Card title="Coming soon" icon="sparkles">
-  Additional integrations (Salesforce, HubSpot, Slack) are on the way. Tell us what you need at [support@octolane.com](mailto:support@octolane.com).
+  Additional integrations (Salesforce, HubSpot, Slack) are on the way. Tell us what you need at [help@octolane.com](mailto:help@octolane.com).
 </Card>
 

--- a/integrations/overview.mdx
+++ b/integrations/overview.mdx
@@ -32,4 +32,4 @@ Octolane uses a combination of native integrations, MCP (Model Context Protocol)
 
 ## Requesting an integration
 
-Don't see the tool you need? Contact us at [support@octolane.com](mailto:support@octolane.com) or request it through **Settings → Integrations → Request Integration**.
+Don't see the tool you need? Contact us at [help@octolane.com](mailto:help@octolane.com) or request it through **Settings → Integrations → Request Integration**.

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -30,5 +30,5 @@ Expected time: **5 minutes**. No admin needed.
   </Card>
 </CardGroup>
 
-Need a hand? [support@octolane.com](mailto:support@octolane.com)
+Need a hand? [help@octolane.com](mailto:help@octolane.com)
 

--- a/support.mdx
+++ b/support.mdx
@@ -7,7 +7,7 @@ description: "How to get help from Octolane"
 
 ## How to reach us
 
-- Email: [support@octolane.com](mailto:support@octolane.com)  
+- Email: [help@octolane.com](mailto:help@octolane.com)  
 - Security issues: [security@octolane.com](mailto:security@octolane.com)  
 - Schedule a call/demo: [octolane.com](https://octolane.com)
 

--- a/support/contact.mdx
+++ b/support/contact.mdx
@@ -10,8 +10,8 @@ We're a small team that moves fast. If you need help, you'll talk to someone who
 
 <CardGroup cols={2}>
 
-<Card title="Email Us" icon="envelope" href="mailto:support@octolane.com">
-  **support@octolane.com**
+<Card title="Email Us" icon="envelope" href="mailto:help@octolane.com">
+  **help@octolane.com**
 
   We respond within a few hours during business hours (9am–6pm PT, Mon–Fri). For urgent issues, email one@octolane.com directly.
 </Card>
@@ -67,7 +67,7 @@ Make sure your email account is connected and showing as active in **Settings �
 </Accordion>
 
 <Accordion title="I need to change my plan or billing info">
-Go to **Settings → Billing** to upgrade, downgrade, or update your payment method. If you need help with invoicing or have a billing question, email support@octolane.com.
+Go to **Settings → Billing** to upgrade, downgrade, or update your payment method. If you need help with invoicing or have a billing question, email help@octolane.com.
 </Accordion>
 
 </AccordionGroup>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates all documentation and assistant instructions that referenced `support@octolane.com` to use the new support address `help@octolane.com`, including mailto links and plain-text mentions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-710c64fb-0be7-4be5-828c-28f5c11a1c46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-710c64fb-0be7-4be5-828c-28f5c11a1c46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

