### PR TITLE
Update MCP docs, welcome page, and standardize support email

### DIFF
--- a/.mintlify/Assistant.md
+++ b/.mintlify/Assistant.md
@@ -20,5 +20,5 @@ You are the Octolane AI assistant - a helpful guide for Octolane's self-driving 
 - Use "Signal" (capitalized) when referring to the website visitor identification feature.
 
 ## Support
-- For questions you can't answer, direct users to support@octolane.com or the founder directly at one@octolane.com.
+- For questions you can't answer, direct users to help@octolane.com or the founder directly at one@octolane.com.
 - For billing questions, direct users to Settings > Billing in the Octolane dashboard.

--- a/docs.json
+++ b/docs.json
@@ -153,22 +153,6 @@
         ]
       },
       {
-        "tab": "API Reference",
-        "icon": "square-terminal",
-        "groups": [
-          {
-            "group": "API Reference",
-            "pages": [
-              "api-reference/introduction",
-              "api-reference/create-opportunity",
-              "api-reference/create-account",
-              "api-reference/create-contact",
-              "api-reference/create-note"
-            ]
-          }
-        ]
-      },
-      {
         "tab": "MCP",
         "icon": "code",
         "groups": [
@@ -183,6 +167,22 @@
               "mcp/use-with-cursor",
               "mcp/authentication",
               "mcp/examples"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "API Reference",
+        "icon": "square-terminal",
+        "groups": [
+          {
+            "group": "API Reference",
+            "pages": [
+              "api-reference/introduction",
+              "api-reference/create-opportunity",
+              "api-reference/create-account",
+              "api-reference/create-contact",
+              "api-reference/create-note"
             ]
           }
         ]

--- a/index.mdx
+++ b/index.mdx
@@ -1,17 +1,30 @@
 ---
-title: "Welcome to Octolane"
-description: "Self-driving CRM docs"
+title: "Octolane Documentation"
+sidebarTitle: "Welcome"
+description: "Documentation for the world's first self-driving CRM."
 ---
 
-# Welcome
+Documentation for the world's first self-driving CRM.
 
-You’re in the right place to set up Octolane. Start with the intro or jump to the quickstart to connect Gmail and Calendar in minutes.
+Octolane connects to your email, calendar, website, and 250+ data sources — then runs your entire sales pipeline automatically. No manual data entry. No stale records. No missed follow-ups.
 
-- [What is Octolane?](/introduction)
-- [Quickstart](/quickstart)
-- [Features](/features/auto-updating)
-- [Integrations](/integrations)
-- [Security & Privacy](/security)
-- [Changelog](/changelog)
-- [Support](/support)
+<CardGroup cols={2}>
+  <Card title="Get Started" icon="rocket" href="/get-started/getting-started">
+    Connect your data sources and see your first auto-detected deal in under 10 minutes.
+  </Card>
+  <Card title="AI Agents" icon="robot" href="/agents/overview">
+    Six agents that find deals, follow up, do outreach, and record meetings — all on autopilot.
+  </Card>
+  <Card title="Signal" icon="radar" href="/signal/what-is-signal">
+    Identify companies visiting your website in real-time and turn anonymous traffic into pipeline.
+  </Card>
+  <Card title="API Reference" icon="square-terminal" href="/api-reference/introduction">
+    Push data into Octolane from any source with our REST API.
+  </Card>
+</CardGroup>
 
+---
+
+<Card title="What's new" icon="clock-rotate-left" href="/changelog">
+  See the latest product updates, new features, and improvements in our changelog.
+</Card>

--- a/integrations.mdx
+++ b/integrations.mdx
@@ -21,6 +21,6 @@ Octolane stays self-driving by tapping into Gmail and Google Calendar with least
 </AccordionGroup>
 
 <Card title="Coming soon" icon="sparkles">
-  Additional integrations (Salesforce, HubSpot, Slack) are on the way. Tell us what you need at [support@octolane.com](mailto:support@octolane.com).
+  Additional integrations (Salesforce, HubSpot, Slack) are on the way. Tell us what you need at [help@octolane.com](mailto:help@octolane.com).
 </Card>
 

--- a/integrations/overview.mdx
+++ b/integrations/overview.mdx
@@ -32,4 +32,4 @@ Octolane uses a combination of native integrations, MCP (Model Context Protocol)
 
 ## Requesting an integration
 
-Don't see the tool you need? Contact us at [support@octolane.com](mailto:support@octolane.com) or request it through **Settings → Integrations → Request Integration**.
+Don't see the tool you need? Contact us at [help@octolane.com](mailto:help@octolane.com) or request it through **Settings → Integrations → Request Integration**.

--- a/mcp/authentication.mdx
+++ b/mcp/authentication.mdx
@@ -63,8 +63,8 @@ API key authentication gives full access to all MCP tools. The key inherits the 
 |---------------|-------------------|
 | Search & query | Read access to CRM data |
 | Create & update | Write access to CRM data |
-| `get_signal_visitors` | Signal enabled on your workspace |
-| `ask_pipeline` | Read access to CRM data |
+| Signal (`get_signal_visitors`, `get_signal_script`) | Signal enabled on your workspace |
+| Workspace (`invite_team_member`) | Admin or owner role |
 
 All team members with API access can generate keys. Workspace admins can revoke any key from **Settings > Integrations > API**.
 

--- a/mcp/examples.mdx
+++ b/mcp/examples.mdx
@@ -16,75 +16,71 @@ Start your day with a complete picture of your pipeline without opening the Octo
 
 **Prompt:**
 ```
-Show me deals closing this month. Which ones are at risk?
-What's gone stale? Give me the quick version.
+Show me our pipeline overview. Which deals are stale?
+What's gone quiet in the last 2 weeks?
 ```
 
 **What Octolane does behind the scenes:**
-1. Calls `get_pipeline` with `period: this_month` to get the pipeline overview
-2. Calls `search_deals` filtered by close date and stale status
-3. Cross-references deal activity to identify at-risk opportunities
+1. Calls `get_pipeline_overview` to get the pipeline summary with deal counts and values per stage
+2. Calls `search_deals` with `days_without_activity: 14` to find stale deals
+3. Presents both in a combined view
 
 **What you get back:**
 
-> **7 deals closing this month - $423K total value**
+> **Pipeline: Sales**
 >
-> **On track (4 deals - $285K):**
-> - Stripe Enterprise Plan - $120K - Negotiation - last activity yesterday
-> - Linear Team Plan - $65K - Proposal sent 3 days ago
-> - Ramp Annual Contract - $55K - Meeting scheduled for Thursday
-> - Webflow Pro - $45K - Contract sent, waiting on signature
+> | Stage | Deals | Total Value | Avg Size |
+> |-------|-------|-------------|----------|
+> | New Lead | 8 | $156K | $19.5K |
+> | Meeting Scheduled | 5 | $210K | $42K |
+> | Proposal | 4 | $185K | $46.3K |
+> | Negotiation | 3 | $196K | $65.3K |
+> | Closed-Won | 3 | $100K | $33.3K |
 >
-> **At risk (3 deals - $138K):**
-> - Notion Annual - $85K - No activity in 14 days, proposal stage
-> - Figma Team - $42K - Meeting was cancelled, no follow-up sent
-> - Vercel Startup Plan - $11K - Went quiet after demo, 18 days ago
->
-> The Follow-Up Agent has drafts ready for Notion and Vercel. Check your approval queue.
+> **Stale deals (no activity in 14+ days):**
+> - Notion Annual - $85K - Proposal - 14 days stale
+> - Figma Team - $42K - Meeting Scheduled - 11 days stale
+> - Vercel Startup Plan - $11K - New Lead - 18 days stale
 
 ---
 
-## 2. Website visitor response
+## 2. Website visitor intelligence
 
 See who's checking out your site and act on it immediately.
 
 **Prompt:**
 ```
-What companies visited our site today? Show me the ones that match
-our ICP. For the top 3, pull up their company details and tell me
-if we already have any contacts or deals with them.
+What companies visited our site recently? Show me the top ones
+with their details. Do we already have any contacts or deals
+with them?
 ```
 
 **What Octolane does behind the scenes:**
-1. Calls `get_signal_visitors` with `period: today` and sorts by ICP score
-2. For the top 3 matches, calls `search_companies` and `search_contacts` to check for existing records
-3. Compiles a combined view with company enrichment data
+1. Calls `get_signal_visitors` to get recent visitors with intent scores
+2. For the top matches, calls `search_accounts` and `search_contacts` to check for existing records
+3. Compiles a combined view with enrichment data
 
 **What you get back:**
 
-> **12 companies visited today. 5 match your ICP (score > 70).**
+> **Recent website visitors:**
 >
-> **Top 3:**
->
-> **1. Linear (94% ICP match)**
+> **1. Linear** (linear.app)
+> - Intent score: 94 | 4 visits this week
 > - 120 employees, Developer Tools, Series B ($52M raised)
-> - Viewed: /pricing (3x), /features, /vs-attio
 > - No existing contacts or deals
-> - *High intent - 3 pricing page views in one session*
+> - *High intent - multiple visits*
 >
-> **2. Ramp (87% ICP match)**
+> **2. Ramp** (ramp.com)
+> - Intent score: 87 | 2 visits
 > - 800 employees, Fintech, Series D ($750M raised)
-> - Viewed: /pricing, /vs-hubspot
 > - Existing contact: Jake Morrison (jake@ramp.com) - no active deal
-> - *Already in your CRM but no deal created yet*
 >
-> **3. Retool (82% ICP match)**
+> **3. Retool** (retool.com)
+> - Intent score: 82 | 3 visits
 > - 450 employees, Developer Tools, Series C ($45M raised)
-> - Viewed: /features, /integrations
 > - No existing contacts or deals
-> - *Browsing product features, early research stage*
 >
-> Want me to create deals for any of these?
+> Want me to create accounts and deals for any of these?
 
 ---
 
@@ -95,211 +91,162 @@ Pull up everything you need before a call without clicking through 5 different C
 **Prompt:**
 ```
 I have a call with Stripe tomorrow. Pull up everything we know about
-them - the deal status, all contacts we've talked to, recent email
-activity, and any action items from past meetings.
+them - the deal status, all contacts, recent emails, and any notes
+or tasks.
 ```
 
 **What Octolane does behind the scenes:**
-1. Calls `search_companies` to find Stripe
-2. Calls `get_company` with all includes (contacts, deals, signal data)
-3. Calls `get_deal` for the active deal with full activity timeline
-4. Filters the activity feed for recent emails and meeting notes
+1. Calls `search_accounts` with `query: "Stripe"` to find the account
+2. Calls `search_deals` with `account_name: "Stripe"` to get active deals
+3. Calls `get_deal_details` on the active deal for full context
+4. Calls `search_emails` with `account_domain: "stripe.com"` for recent correspondence
+5. Calls `get_notes` with `account_name: "Stripe"` for logged notes
+6. Calls `get_tasks` for open tasks linked to the deal
 
 **What you get back:**
 
 > **Stripe - Enterprise Plan**
 > - **Stage:** Negotiation | **Value:** $120K | **Close date:** April 15
-> - **Owner:** Sarah (you) | **Days in stage:** 5
+> - **Owner:** Sarah (you) | **Next steps:** Send SOC 2 report
 >
 > **Contacts:**
-> - Sarah Chen, VP of Sales (sarah@stripe.com) - primary contact, 14 emails exchanged
-> - David Park, Head of RevOps (david@stripe.com) - joined last 2 meetings
-> - Lisa Wu, Procurement (lisa@stripe.com) - CC'd on contract discussion
+> - Sarah Chen, VP of Sales (sarah@stripe.com) - primary contact
+> - David Park, Head of RevOps (david@stripe.com) - technical evaluator
+> - Lisa Wu, Procurement (lisa@stripe.com) - CC'd on contract thread
 >
-> **Recent activity:**
-> - Mar 6: Email from Sarah Chen - "Need SOC 2 report before procurement can sign off"
-> - Mar 4: 45-min meeting - discussed pricing tiers, they want custom enterprise pricing
-> - Mar 1: Proposal sent ($120K/yr for 50 seats)
-> - Feb 27: Demo call - David Park attended, asked about API access
+> **Recent emails:**
+> - Mar 6: From Sarah Chen - "Need SOC 2 report before procurement can sign off"
+> - Mar 4: To Sarah Chen - Pricing follow-up after meeting
+> - Mar 1: To Sarah Chen - Proposal sent ($120K/yr for 50 seats)
 >
-> **Open action items:**
-> - Send SOC 2 report to Lisa Wu (from Mar 6 email)
-> - Follow up on custom pricing structure (from Mar 4 meeting)
-> - Share API documentation with David Park (from Feb 27 demo)
+> **Notes:**
+> - Mar 4: "Meeting notes - discussed custom pricing, David wants SSO included"
+> - Feb 27: "Demo call - David asked about API access and webhooks"
 >
-> **Signal:** Stripe visited your docs 3 times this week (API reference, security page)
+> **Open tasks:**
+> - Send SOC 2 report to Lisa Wu (High priority, due Apr 10)
+> - Share API docs with David Park (Medium priority)
 
 ---
 
-## 4. Pipeline reporting
+## 4. Deal creation flow
 
-Get the numbers your VP of Sales asks for in 10 seconds instead of building a report.
+Create a deal with all the linked records in one conversation.
 
 **Prompt:**
 ```
-What's our pipeline value this quarter compared to last quarter?
-Break it down by stage. Which rep has the most deals and which
-rep has the most stale deals?
+Just had a great call with the CTO of Linear. Create a deal -
+$65K annual contract, meeting scheduled stage. Main contact is
+karri@linear.app. Add a note with the call summary.
 ```
 
 **What Octolane does behind the scenes:**
-1. Calls `get_pipeline` for `this_quarter` and `last_quarter`
-2. Calls `ask_pipeline` for rep-level performance data
-3. Compares the two periods and calculates deltas
+1. Calls `create_account` with `domain: "linear.app"` (auto-enriched)
+2. Calls `create_contact` with `email: "karri@linear.app"` (auto-enriched)
+3. Calls `get_pipeline_overview` to get the pipeline ID
+4. Calls `list_pipeline_stages` to find the "Meeting Scheduled" stage ID
+5. Calls `create_deal` with all the details
+6. Calls `create_note` linked to the new deal
 
 **What you get back:**
 
-> **Q1 2026 vs Q4 2025:**
+> **Created:**
+> - Account: Linear (linear.app) - auto-enriched with company data
+> - Contact: karri@linear.app - auto-enriched with job title and profile
+> - Deal: "Linear - Annual Contract" - $65K - Meeting Scheduled
+> - Note: Call summary logged on the deal
 >
-> | Stage | Q1 2026 | Q4 2025 | Change |
-> |-------|---------|---------|--------|
-> | New Lead | $156K (8 deals) | $120K (6 deals) | +30% |
-> | Meeting Scheduled | $210K (5 deals) | $180K (4 deals) | +17% |
-> | Proposal | $185K (4 deals) | $195K (5 deals) | -5% |
-> | Negotiation | $196K (3 deals) | $145K (3 deals) | +35% |
-> | Closed-Won | $100K (3 deals) | $340K (8 deals) | -71% |
->
-> **Total pipeline:** $847K (Q1) vs $980K (Q4) - down 14%, but it's early in the quarter.
->
-> **Rep breakdown:**
-> - **Sarah:** 9 deals, $380K total - 0 stale
-> - **Mike:** 8 deals, $290K total - 3 stale (oldest: 18 days)
-> - **Alex:** 6 deals, $177K total - 1 stale
->
-> Mike has 3 stale deals. The Follow-Up Agent has 2 drafts ready for his queue.
+> The Follow-Up Agent is now monitoring this deal for stale conversations.
 
 ---
 
-## 5. Lead qualification
+## 5. Email and meeting history
 
-A new lead comes in and you want to know everything about them before responding.
+Look up your communication history with any contact or company.
 
 **Prompt:**
 ```
-A new lead just came in from our website form - john@linearapp.com.
-What do we know about their company? Score them against our ICP.
-Do we have any existing contacts or deals with them?
+Show me all emails and meetings with Notion in the last month.
+What was the last thing we discussed?
 ```
 
 **What Octolane does behind the scenes:**
-1. Calls `search_contacts` to check if john@linearapp.com exists
-2. Calls `search_companies` for linear.app to check for existing records
-3. Calls `get_signal_visitors` to check if Linear has been visiting the site
-4. Cross-references against ICP criteria
+1. Calls `search_emails` with `account_domain: "notion.so"` to find email threads
+2. Calls `search_meetings` with `query: "Notion"` to find meeting records
+3. Combines and sorts by date
 
 **What you get back:**
 
-> **Linear (linear.app) - 94% ICP match**
+> **Emails with Notion (last 30 days):**
+> - Mar 6: To sarah@notion.so - Proposal follow-up (no reply)
+> - Feb 22: From sarah@notion.so - "Looks good, let me loop in procurement"
+> - Feb 20: To sarah@notion.so - Proposal sent ($85K annual)
 >
-> **Company:**
-> - 120 employees | Developer Tools | San Francisco
-> - Series B - $52M raised (Sequoia, Accel)
-> - Tech stack: React, TypeScript, PostgreSQL, Vercel
+> **Meetings:**
+> - Feb 18: Discovery call with Sarah - 30 min
+>   Summary: Discussed pain points with current CRM, interested in AI features
 >
-> **ICP scoring:**
-> - Company size: 120 employees (target: 50-500) ✓
-> - Industry: Developer Tools ✓
-> - Funding: Series B ✓
-> - Location: US ✓
-> - Score: **94/100**
->
-> **Existing records:** None - new prospect
->
-> **Signal activity:** Linear visited your site 4 times this week
-> - Pages viewed: /, /pricing (3x), /features, /vs-hubspot
-> - High-intent signal: repeated pricing page views
->
-> **Contact (from form):**
-> - John Martinez, john@linearapp.com
-> - Title not yet enriched (enrichment pending)
->
-> This is a strong lead. They match your ICP, they've been researching pricing, and they submitted a form. Want me to create a deal?
+> **Last interaction:** Proposal follow-up email on Mar 6 - no reply in 8 days. This deal may need attention.
 
 ---
 
-## 6. Deal deep-dive
+## 6. Task management
 
-Get the full story on a deal without clicking through 10 screens.
+Manage your follow-ups and action items from your AI assistant.
 
 **Prompt:**
 ```
-Give me the complete picture on the Stripe deal. Full timeline,
-everyone involved, all emails and meetings, and what needs to
-happen next.
+What tasks do I have open? Show me what's overdue and what's
+coming up this week. Mark the Stripe SOC 2 task as done.
 ```
 
 **What Octolane does behind the scenes:**
-1. Calls `search_deals` to find the Stripe deal
-2. Calls `get_deal` with full activity timeline and contacts
-3. Calls `get_activity_feed` for the complete history
+1. Calls `get_tasks` to get all open tasks
+2. Filters by due date for overdue and this-week buckets
+3. Calls `update_task` with `completed: true` on the SOC 2 task
 
 **What you get back:**
 
-> **Stripe - Enterprise Plan**
-> - Created: Feb 15 | Stage: Negotiation | Value: $120K | Close: Apr 15
+> **Overdue (2):**
+> - Share API docs with David Park (Stripe) - due Apr 8 - Medium
+> - Follow up with Notion on proposal - due Apr 10 - High
 >
-> **People involved:**
-> - Sarah Chen (VP Sales) - your main champion, replies within hours
-> - David Park (Head of RevOps) - technical evaluator, joined last 2 meetings
-> - Lisa Wu (Procurement) - gate-keeper, needs SOC 2 before signing
+> **This week (3):**
+> - Schedule demo with Linear - due Apr 16 - Medium
+> - Send case study to Ramp - due Apr 17 - Low
+> - Review Retool pricing proposal - due Apr 18 - High
 >
-> **Full timeline:**
-> - Feb 15: Deal created by Deal Finder Agent from email thread
-> - Feb 18: First meeting - discovery call, 30 min. Sarah described pain points with HubSpot
-> - Feb 22: Email thread - pricing discussion, asked about enterprise tier
-> - Feb 27: Demo - David Park attended, asked about API and webhooks
-> - Mar 1: Proposal sent - $120K/yr for 50 seats, enterprise features
-> - Mar 4: Meeting - discussed custom pricing, David wants SSO included
-> - Mar 6: Email from Sarah - "Lisa needs SOC 2 report before procurement"
-> - Mar 7: Lisa CC'd on thread - asked about data residency
->
-> **What needs to happen:**
-> 1. Send SOC 2 report to Lisa Wu (blocker)
-> 2. Respond to data residency question (Lisa, Mar 7)
-> 3. Finalize custom pricing with SSO included (David, from Mar 4 meeting)
-> 4. Schedule follow-up call to address procurement questions
->
-> **Risk:** The deal is in good shape but procurement is a gate. Get the SOC 2 report to Lisa ASAP.
+> **Done:** Marked "Send SOC 2 report to Stripe" as complete.
 
 ---
 
-## 7. Signal intelligence sweep
+## 7. Stale deal sweep
 
-Find high-intent visitors who haven't been contacted yet.
+Find deals that need attention and take action.
 
 **Prompt:**
 ```
-Which companies visited our pricing page 3+ times this week and
-haven't been contacted yet? Show me the ones that match our ICP
-with full company details.
+Show me all deals that haven't had any activity in 2 weeks.
+For each one, show the last email and create a follow-up task.
 ```
 
 **What Octolane does behind the scenes:**
-1. Calls `get_signal_visitors` with `page_filter: "/pricing"` and `period: "this_week"`
-2. Filters for 3+ visits
-3. Calls `search_contacts` and `search_deals` to check for existing relationships
-4. Returns only companies with no prior contact
+1. Calls `search_deals` with `days_without_activity: 14`
+2. For each stale deal, calls `search_emails` with the account domain to find the last email
+3. Calls `create_task` for each stale deal with a follow-up reminder
 
 **What you get back:**
 
-> **3 companies visited /pricing 3+ times this week with no prior contact:**
+> **3 stale deals (no activity in 14+ days):**
 >
-> **1. Linear (94% ICP match)**
-> - 120 employees | Developer Tools | Series B
-> - 4 pricing page views between Mon and Fri
-> - Also viewed: /features, /vs-hubspot, /integrations
-> - No contacts in CRM, no existing deals
+> **1. Notion Annual - $85K - Proposal**
+> - Last email: Mar 6 - Proposal follow-up (no reply, 38 days ago)
+> - Task created: "Follow up with Notion on proposal" - due tomorrow - High
 >
-> **2. Loom (79% ICP match)**
-> - 200 employees | Video/Productivity | Series C
-> - 3 pricing page views, all on Wednesday
-> - Also viewed: /pricing, /security
-> - No contacts in CRM, no existing deals
+> **2. Figma Team - $42K - Meeting Scheduled**
+> - Last email: Mar 2 - Meeting confirmation (cancelled, never rescheduled)
+> - Task created: "Reschedule meeting with Figma" - due tomorrow - High
 >
-> **3. Descript (75% ICP match)**
-> - 150 employees | Media/AI | Series C
-> - 3 pricing page views spread across the week
-> - Also viewed: /features, /for-sales-teams
-> - No contacts in CRM, no existing deals
->
-> All three are strong ICP matches actively researching pricing. Want me to create prospect records and have the Outreach Agent draft messages for them?
+> **3. Vercel Startup - $11K - New Lead**
+> - Last email: Feb 25 - Intro email (no reply, 47 days ago)
+> - Task created: "Re-engage Vercel or close as lost" - due tomorrow - Medium

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -1,14 +1,14 @@
 ---
 title: "Octolane MCP Server"
 sidebarTitle: "Overview"
-description: "Connect Claude, ChatGPT, Cursor, Windsurf, or any MCP client to your Octolane CRM - search deals, manage pipeline, trigger agents, and run your sales process through natural language."
+description: "Connect Claude, ChatGPT, Cursor, Windsurf, or any MCP client to your Octolane CRM - search deals, manage pipeline, access emails and meetings, and run your sales process through natural language."
 ---
 
 # Octolane MCP Server
 
 Other CRM MCP servers let you read and write records. Octolane's MCP gives you a window into a self-driving sales team.
 
-Connect your AI assistant to Octolane and you get more than CRUD operations on a database. You can query your pipeline in natural language, see which companies are visiting your website right now via Signal, get full deal intelligence with activity timelines, and create records that your agents immediately act on - enriching contacts, detecting deals, and drafting follow-ups automatically.
+Connect your AI assistant to Octolane and you get more than CRUD operations on a database. You can search deals with advanced filters, pull up full email threads and meeting transcripts, see which companies are visiting your website via Signal, create tasks and notes linked to any record, and manage your pipeline stages — all through natural language. Records you create are immediately picked up by Octolane's agents for enrichment and follow-up.
 
 No other CRM offers this.
 
@@ -26,23 +26,42 @@ Authenticate with your API key in the `X-API-Key` header. Same key you use for t
 
 <CardGroup cols={2}>
 
-<Card title="Search & query" icon="magnifying-glass">
-  Search deals, contacts, and companies across your CRM. Get pipeline overviews with deal counts and values per stage. Pull activity feeds for any record.
+<Card title="Search everything" icon="magnifying-glass">
+  Search deals, contacts, accounts, emails, and meetings. Filter deals by stage, size, close date, or staleness. Look up email threads and meeting transcripts by keyword or attendee.
 </Card>
 
 <Card title="Create & update" icon="plus">
-  Create opportunities, contacts, accounts, and notes. Update deal stages, values, close dates, and custom fields. Records are automatically enriched and picked up by agents.
+  Create deals, contacts, accounts, notes, and tasks. Move deals between stages. Mark tasks complete. Records are automatically enriched and picked up by agents.
 </Card>
 
-<Card title="Agent commands" icon="microchip-ai">
-  Review Signal website visitors and their ICP scores. Ask natural language questions about your pipeline. Get deal intelligence that would take 10 clicks in a traditional CRM.
+<Card title="Signal intelligence" icon="radar">
+  See which companies are visiting your website with intent scores and visit counts. Get your Signal tracking script to install on your site.
 </Card>
 
-<Card title="Pipeline intelligence" icon="chart-line">
-  Ask about deal status, forecasts, stale deals, and at-risk opportunities. Get pipeline value by stage, conversion rates, and rep performance - all through conversation.
+<Card title="Pipeline management" icon="chart-line">
+  Get pipeline overviews with deal counts and values per stage. List stages, rename pipelines, and advance deals through your funnel.
+</Card>
+
+<Card title="Email & meetings" icon="envelope">
+  Search email conversations by contact, company, or keyword. Pull up full email threads. Find past meetings with transcripts and summaries.
+</Card>
+
+<Card title="Workspace" icon="users">
+  Check your identity and subscription, list team members, invite new people to your workspace — all from your AI assistant.
 </Card>
 
 </CardGroup>
+
+## 29 tools, 6 categories
+
+| Category | Tools |
+|----------|-------|
+| Search & Query | `search_deals`, `search_contacts`, `search_accounts`, `search_emails`, `search_meetings`, `get_deal_details`, `get_pipeline_overview`, `get_signal_visitors`, `get_email_thread`, `get_notes`, `get_tasks`, `get_current_user` |
+| Create & Update | `create_deal`, `create_contact`, `create_account`, `create_note`, `create_task`, `update_deal_stage`, `move_deal_to_next_stage`, `update_note`, `update_task` |
+| Pipeline Management | `list_pipeline_stages`, `rename_pipeline` |
+| Field Discovery | `get_account_fields`, `get_contact_fields`, `get_deal_fields` |
+| Signal | `get_signal_visitors`, `get_signal_script` |
+| Workspace | `list_workspace_members`, `invite_team_member`, `get_current_user` |
 
 ## Why Octolane's MCP is different
 
@@ -50,13 +69,13 @@ Most CRM MCP servers are a thin wrapper around a REST API. You can create a cont
 
 Octolane's MCP connects your AI assistant to a CRM that thinks for itself:
 
-- **Records come alive.** Create a contact via MCP and Octolane's agents immediately enrich it with job title, company size, funding data, and social profiles. Create a deal and the Follow-Up Agent starts monitoring the conversation for stale threads. You're not just writing to a database - you're activating a sales team.
+- **Records come alive.** Create a contact via MCP and Octolane's agents immediately enrich it with job title, company size, funding data, and social profiles. Create a deal and the Follow-Up Agent starts monitoring the conversation for stale threads. You're not just writing to a database — you're activating a sales team.
 
-- **Signal intelligence.** Ask "What companies visited our pricing page this week?" and get real-time website visitor data from Signal, scored against your ideal customer profile. No other CRM MCP server gives you this.
+- **Signal intelligence.** Ask "What companies visited our site?" and get real-time website visitor data from Signal, scored by intent. No other CRM MCP server gives you this.
 
-- **Natural language pipeline queries.** Ask "Which deals are at risk?" or "What's our pipeline value this quarter vs last quarter?" and get instant answers without building reports or writing filters.
+- **Full communication history.** Search emails and meetings across your CRM. Pull up complete email threads and meeting transcripts with summaries. Get the full picture on any deal without leaving your AI assistant.
 
-- **Full deal context.** Pull up a deal and get the complete picture: stage, value, associated contacts, email threads, meeting transcripts, agent actions, and next steps. Everything your AI assistant needs to help you sell.
+- **Task and note management.** Create follow-up tasks with due dates and priorities. Log meeting notes linked to deals. Mark tasks complete when done. Your AI assistant becomes your CRM command center.
 
 ## Supported clients
 
@@ -81,7 +100,7 @@ Octolane MCP works with any client that supports the Model Context Protocol:
 </Card>
 
 <Card title="Tools reference" icon="wrench" href="/mcp/tools-reference">
-  Full reference for every MCP tool with parameters and examples.
+  Full reference for all 29 MCP tools with parameters and examples.
 </Card>
 
 <Card title="Examples & workflows" icon="lightbulb" href="/mcp/examples">

--- a/mcp/quickstart.mdx
+++ b/mcp/quickstart.mdx
@@ -140,7 +140,7 @@ Open your AI client and ask:
 What tools do you have from Octolane?
 ```
 
-You should see a list of available tools including `search_deals`, `get_pipeline`, `get_signal_visitors`, and others. If you see them, you're connected.
+You should see a list of available tools including `search_deals`, `get_pipeline_overview`, `get_signal_visitors`, and others. If you see them, you're connected.
 
 <Warning>
 If the tools don't show up, double-check your API key and make sure you restarted your client after adding the config.
@@ -168,7 +168,11 @@ What's our pipeline value by stage?
 Pull up everything we know about Acme Corp
 ```
 
-That's it. Your AI assistant now has full access to your Octolane CRM - including your pipeline, contacts, Signal data, and agent activity.
+```
+What are my open tasks this week?
+```
+
+That's it. Your AI assistant now has full access to your Octolane CRM — including your pipeline, contacts, emails, meetings, tasks, Signal data, and more.
 
 </Step>
 
@@ -190,7 +194,7 @@ You're not just writing to a database. You're activating a self-driving sales te
 <CardGroup cols={2}>
 
 <Card title="Tools reference" icon="wrench" href="/mcp/tools-reference">
-  See every available MCP tool with parameters and example responses.
+  See all 29 MCP tools with parameters and examples.
 </Card>
 
 <Card title="Examples & workflows" icon="lightbulb" href="/mcp/examples">

--- a/mcp/tools-reference.mdx
+++ b/mcp/tools-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: "MCP Tools Reference"
 sidebarTitle: "Tools Reference"
-description: "Complete reference for all Octolane MCP tools - search, create, update records, trigger agents, and query your pipeline via any MCP client."
+description: "Complete reference for all 29 Octolane MCP tools - search, create, update records, manage pipeline, access Signal data, and more."
 ---
 
 # MCP Tools Reference
@@ -20,73 +20,56 @@ Tools for finding and retrieving data from your CRM.
 
 ### `search_deals`
 
-Search deals by name, stage, value, owner, or any custom field.
+Search deals with filters for pipeline, stage, account, contact, deal size, close date, and staleness.
 
 <Expandable title="Parameters">
-  <ParamField body="query" type="string" required>
-    Search term to match against deal name, company, or description.
+  <ParamField body="search_query" type="string">
+    Search by deal/opportunity name.
   </ParamField>
-  <ParamField body="stage" type="string">
-    Filter by pipeline stage (e.g., "Negotiation", "Proposal").
+  <ParamField body="pipeline_name" type="string">
+    Filter by pipeline name (e.g., "Sales").
   </ParamField>
-  <ParamField body="owner" type="string">
-    Filter by deal owner email or name.
+  <ParamField body="stage_name" type="string">
+    Filter by stage name (e.g., "Negotiation", "Won").
   </ParamField>
-  <ParamField body="min_value" type="number">
+  <ParamField body="account_name" type="string">
+    Filter by associated company/account name.
+  </ParamField>
+  <ParamField body="contact_name" type="string">
+    Filter by associated contact name.
+  </ParamField>
+  <ParamField body="min_amount" type="number">
     Minimum deal value.
   </ParamField>
-  <ParamField body="max_value" type="number">
+  <ParamField body="max_amount" type="number">
     Maximum deal value.
   </ParamField>
-  <ParamField body="status" type="string">
-    Deal status: `open`, `won`, `lost`. Defaults to `open`.
+  <ParamField body="close_date_from" type="string">
+    Start of close date range (ISO 8601).
   </ParamField>
-  <ParamField body="limit" type="number">
-    Maximum results to return. Defaults to 20, max 100.
+  <ParamField body="close_date_to" type="string">
+    End of close date range (ISO 8601).
+  </ParamField>
+  <ParamField body="days_without_activity" type="integer">
+    Filter to deals with no activity for N days (stale deals).
+  </ParamField>
+  <ParamField body="limit" type="integer">
+    Maximum results to return. Defaults to 10, max 25.
   </ParamField>
 </Expandable>
 
 <Expandable title="Example">
 
-**Prompt:** "Show me all open deals worth more than $50K"
+**Prompt:** "Show me all stale deals worth more than $50K"
 
 **Tool call:**
 ```json
 {
   "tool": "search_deals",
   "arguments": {
-    "status": "open",
-    "min_value": 50000
+    "min_amount": 50000,
+    "days_without_activity": 14
   }
-}
-```
-
-**Response:**
-```json
-{
-  "deals": [
-    {
-      "id": "deal_abc123",
-      "name": "Stripe - Enterprise Plan",
-      "stage": "Negotiation",
-      "value": 120000,
-      "owner": "sarah@yourcompany.com",
-      "company": "Stripe",
-      "last_activity": "2026-03-06T14:30:00Z",
-      "days_in_stage": 5
-    },
-    {
-      "id": "deal_def456",
-      "name": "Notion - Annual Contract",
-      "stage": "Proposal",
-      "value": 85000,
-      "owner": "mike@yourcompany.com",
-      "company": "Notion",
-      "last_activity": "2026-03-04T09:15:00Z",
-      "days_in_stage": 12
-    }
-  ],
-  "total": 2
 }
 ```
 
@@ -96,20 +79,20 @@ Search deals by name, stage, value, owner, or any custom field.
 
 ### `search_contacts`
 
-Search contacts by name, email, company, or any field.
+Search contacts by name, email, company, or job title.
 
 <Expandable title="Parameters">
-  <ParamField body="query" type="string" required>
-    Search term to match against name, email, or company.
+  <ParamField body="query" type="string">
+    Search by contact name or email.
   </ParamField>
-  <ParamField body="company" type="string">
-    Filter by company name or domain.
+  <ParamField body="company_name" type="string">
+    Filter by company name.
   </ParamField>
-  <ParamField body="title" type="string">
-    Filter by job title (partial match).
+  <ParamField body="job_title" type="string">
+    Filter by job title.
   </ParamField>
-  <ParamField body="limit" type="number">
-    Maximum results to return. Defaults to 20, max 100.
+  <ParamField body="limit" type="integer">
+    Maximum results to return. Defaults to 10, max 25.
   </ParamField>
 </Expandable>
 
@@ -122,27 +105,8 @@ Search contacts by name, email, company, or any field.
 {
   "tool": "search_contacts",
   "arguments": {
-    "company": "Stripe"
+    "company_name": "Stripe"
   }
-}
-```
-
-**Response:**
-```json
-{
-  "contacts": [
-    {
-      "id": "contact_xyz789",
-      "name": "Sarah Chen",
-      "email": "sarah@stripe.com",
-      "title": "VP of Sales",
-      "company": "Stripe",
-      "phone": "+1 (415) 555-0142",
-      "linkedin": "https://linkedin.com/in/sarachen",
-      "last_contacted": "2026-03-06T14:30:00Z"
-    }
-  ],
-  "total": 1
 }
 ```
 
@@ -150,40 +114,35 @@ Search contacts by name, email, company, or any field.
 
 ---
 
-### `search_companies`
+### `search_accounts`
 
-Search companies by name, domain, industry, or size.
+Search accounts (companies) by name, domain, or industry.
 
 <Expandable title="Parameters">
-  <ParamField body="query" type="string" required>
-    Search term to match against company name or domain.
+  <ParamField body="query" type="string">
+    Search by company name or domain.
+  </ParamField>
+  <ParamField body="domain" type="string">
+    Filter by company domain.
   </ParamField>
   <ParamField body="industry" type="string">
     Filter by industry.
   </ParamField>
-  <ParamField body="min_size" type="number">
-    Minimum employee count.
-  </ParamField>
-  <ParamField body="max_size" type="number">
-    Maximum employee count.
-  </ParamField>
-  <ParamField body="limit" type="number">
-    Maximum results to return. Defaults to 20, max 100.
+  <ParamField body="limit" type="integer">
+    Maximum results to return. Defaults to 10, max 25.
   </ParamField>
 </Expandable>
 
 <Expandable title="Example">
 
-**Prompt:** "Find SaaS companies with 100-500 employees"
+**Prompt:** "Find SaaS companies in our CRM"
 
 **Tool call:**
 ```json
 {
-  "tool": "search_companies",
+  "tool": "search_accounts",
   "arguments": {
-    "industry": "SaaS",
-    "min_size": 100,
-    "max_size": 500
+    "industry": "SaaS"
   }
 }
 ```
@@ -192,19 +151,95 @@ Search companies by name, domain, industry, or size.
 
 ---
 
-### `get_deal`
+### `search_emails`
 
-Get full details of a specific deal including activity timeline, associated contacts, and agent actions.
+Search email conversations by contact, company domain, keyword, or direction.
 
 <Expandable title="Parameters">
-  <ParamField body="deal_id" type="string" required>
-    The deal ID.
+  <ParamField body="contact_email" type="string">
+    Search emails involving this email address.
   </ParamField>
-  <ParamField body="include_activity" type="boolean">
-    Include the full activity timeline. Defaults to true.
+  <ParamField body="account_domain" type="string">
+    Search emails involving this company domain.
   </ParamField>
-  <ParamField body="include_contacts" type="boolean">
-    Include associated contacts. Defaults to true.
+  <ParamField body="search_query" type="string">
+    Search by email subject or content.
+  </ParamField>
+  <ParamField body="label" type="string">
+    Filter by direction: `sent`, `inbox`, or `all`. Defaults to `all`.
+  </ParamField>
+  <ParamField body="limit" type="integer">
+    Maximum results to return. Defaults to 10, max 25.
+  </ParamField>
+</Expandable>
+
+<Expandable title="Example">
+
+**Prompt:** "Show me all emails we've sent to Stripe"
+
+**Tool call:**
+```json
+{
+  "tool": "search_emails",
+  "arguments": {
+    "account_domain": "stripe.com",
+    "label": "sent"
+  }
+}
+```
+
+</Expandable>
+
+---
+
+### `search_meetings`
+
+Search past and upcoming meetings by keyword, attendee, or date range.
+
+<Expandable title="Parameters">
+  <ParamField body="query" type="string">
+    Search keywords for meeting title, summary, transcript, or attendee. Omit for purely temporal queries like "my next meeting".
+  </ParamField>
+  <ParamField body="start_date" type="string">
+    Start of date range (ISO 8601).
+  </ParamField>
+  <ParamField body="end_date" type="string">
+    End of date range (ISO 8601).
+  </ParamField>
+  <ParamField body="sort" type="string">
+    Sort order for start_time: `asc` for upcoming, `desc` for recent. Defaults to `desc`.
+  </ParamField>
+  <ParamField body="limit" type="integer">
+    Maximum results to return. Defaults to 10, max 25.
+  </ParamField>
+</Expandable>
+
+<Expandable title="Example">
+
+**Prompt:** "What meetings do I have this week?"
+
+**Tool call:**
+```json
+{
+  "tool": "search_meetings",
+  "arguments": {
+    "start_date": "2026-04-14T00:00:00Z",
+    "sort": "asc"
+  }
+}
+```
+
+</Expandable>
+
+---
+
+### `get_deal_details`
+
+Get full details of a specific deal including associated contacts, account, notes, tasks, and next steps.
+
+<Expandable title="Parameters">
+  <ParamField body="opportunity_id" type="string" required>
+    The deal/opportunity ID. Use `search_deals` to find it.
   </ParamField>
 </Expandable>
 
@@ -212,94 +247,135 @@ Get full details of a specific deal including activity timeline, associated cont
 
 **Prompt:** "Pull up the Stripe deal"
 
-**Response includes:** deal details, current stage, value, close date, all associated contacts with roles, full activity timeline (emails, meetings, agent actions, notes), action items, and next steps.
+First call `search_deals` with `search_query: "Stripe"` to get the ID, then:
+
+```json
+{
+  "tool": "get_deal_details",
+  "arguments": {
+    "opportunity_id": "deal_abc123"
+  }
+}
+```
+
+Returns deal details, current stage, value, close date, all associated contacts, notes, tasks, and next steps.
 
 </Expandable>
 
 ---
 
-### `get_contact`
+### `get_pipeline_overview`
 
-Get full details of a contact including enrichment data, communication history, and associated deals.
-
-<Expandable title="Parameters">
-  <ParamField body="contact_id" type="string" required>
-    The contact ID.
-  </ParamField>
-  <ParamField body="include_deals" type="boolean">
-    Include associated deals. Defaults to true.
-  </ParamField>
-  <ParamField body="include_activity" type="boolean">
-    Include communication history. Defaults to true.
-  </ParamField>
-</Expandable>
-
----
-
-### `get_company`
-
-Get full details of a company including enrichment data, contacts, deals, and Signal visit history.
+Get a summary of your sales pipeline(s) showing deal counts, total values, and average deal size by stage.
 
 <Expandable title="Parameters">
-  <ParamField body="company_id" type="string" required>
-    The company ID.
-  </ParamField>
-  <ParamField body="include_contacts" type="boolean">
-    Include all contacts at this company. Defaults to true.
-  </ParamField>
-  <ParamField body="include_deals" type="boolean">
-    Include all deals with this company. Defaults to true.
-  </ParamField>
-  <ParamField body="include_signal" type="boolean">
-    Include Signal website visit data. Defaults to true.
-  </ParamField>
-</Expandable>
-
----
-
-### `get_pipeline`
-
-Get a pipeline overview with deal counts, values, and conversion rates per stage.
-
-<Expandable title="Parameters">
-  <ParamField body="pipeline_id" type="string">
-    Specific pipeline ID. Returns the default pipeline if omitted.
-  </ParamField>
-  <ParamField body="period" type="string">
-    Time period for metrics: `this_week`, `this_month`, `this_quarter`, `last_quarter`. Defaults to `this_month`.
+  <ParamField body="pipeline_name" type="string">
+    Filter by pipeline name. Omit to see all pipelines.
   </ParamField>
 </Expandable>
 
 <Expandable title="Example">
 
-**Prompt:** "What's our pipeline look like this quarter?"
+**Prompt:** "What's our pipeline look like?"
 
 **Tool call:**
 ```json
 {
-  "tool": "get_pipeline",
+  "tool": "get_pipeline_overview",
+  "arguments": {}
+}
+```
+
+Returns pipeline ID, name, and breakdown by stage with deal counts, total values, and average deal size.
+
+</Expandable>
+
+---
+
+### `get_signal_visitors`
+
+Retrieve website visitors identified by Octolane Signal with visit counts, intent scores, and activity dates.
+
+<Expandable title="Parameters">
+  <ParamField body="search_query" type="string">
+    Search by company name or domain.
+  </ParamField>
+  <ParamField body="page" type="integer">
+    Page number for pagination. Defaults to 1.
+  </ParamField>
+  <ParamField body="limit" type="integer">
+    Results per page. Defaults to 10, max 50.
+  </ParamField>
+</Expandable>
+
+<Expandable title="Example">
+
+**Prompt:** "What companies have been visiting our site?"
+
+**Tool call:**
+```json
+{
+  "tool": "get_signal_visitors",
   "arguments": {
-    "period": "this_quarter"
+    "limit": 20
   }
 }
 ```
 
-**Response:**
+Returns companies with visit counts, intent scores, and activity dates.
+
+</Expandable>
+
+---
+
+### `get_email_thread`
+
+Get the full email thread conversation by thread ID.
+
+<Expandable title="Parameters">
+  <ParamField body="thread_id" type="string" required>
+    The email thread ID. Get this from `search_emails` results.
+  </ParamField>
+</Expandable>
+
+---
+
+### `get_notes`
+
+Search and retrieve notes linked to a deal, contact, or account. Supports lookup by name, email, or domain — no ID required.
+
+<Expandable title="Parameters">
+  <ParamField body="entity_id" type="string">
+    Direct entity UUID (deal, contact, or account).
+  </ParamField>
+  <ParamField body="account_name" type="string">
+    Find notes by company name.
+  </ParamField>
+  <ParamField body="account_domain" type="string">
+    Find notes by company domain.
+  </ParamField>
+  <ParamField body="contact_name" type="string">
+    Find notes by contact name.
+  </ParamField>
+  <ParamField body="contact_email" type="string">
+    Find notes by contact email.
+  </ParamField>
+  <ParamField body="limit" type="integer">
+    Maximum results. Defaults to 10, max 25.
+  </ParamField>
+</Expandable>
+
+<Expandable title="Example">
+
+**Prompt:** "Show me all notes on the Stripe account"
+
+**Tool call:**
 ```json
 {
-  "pipeline": "Default Pipeline",
-  "period": "this_quarter",
-  "total_value": 847000,
-  "total_deals": 23,
-  "stages": [
-    { "name": "New Lead", "deals": 8, "value": 156000 },
-    { "name": "Meeting Scheduled", "deals": 5, "value": 210000 },
-    { "name": "Proposal", "deals": 4, "value": 185000 },
-    { "name": "Negotiation", "deals": 3, "value": 196000 },
-    { "name": "Closed-Won", "deals": 3, "value": 100000 }
-  ],
-  "at_risk": 4,
-  "stale": 6
+  "tool": "get_notes",
+  "arguments": {
+    "account_name": "Stripe"
+  }
 }
 ```
 
@@ -307,20 +383,47 @@ Get a pipeline overview with deal counts, values, and conversion rates per stage
 
 ---
 
-### `get_activity_feed`
+### `get_tasks`
 
-Get recent activity for a deal, contact, or company.
+Get tasks assigned to you or linked to a specific deal, contact, or account.
 
 <Expandable title="Parameters">
-  <ParamField body="record_id" type="string" required>
-    The ID of the deal, contact, or company.
+  <ParamField body="entity_id" type="string">
+    Get tasks linked to this entity UUID.
   </ParamField>
-  <ParamField body="record_type" type="string" required>
-    Type of record: `deal`, `contact`, `company`.
+  <ParamField body="entity_type" type="string">
+    Type of entity: `account`, `contact`, or `opportunity`. Required when `entity_id` is provided.
   </ParamField>
-  <ParamField body="limit" type="number">
-    Maximum activity entries to return. Defaults to 20.
+  <ParamField body="include_completed" type="boolean">
+    Include completed tasks. Defaults to false.
   </ParamField>
+  <ParamField body="limit" type="integer">
+    Maximum results. Defaults to 15, max 25.
+  </ParamField>
+</Expandable>
+
+<Expandable title="Example">
+
+**Prompt:** "What are my open tasks?"
+
+**Tool call:**
+```json
+{
+  "tool": "get_tasks",
+  "arguments": {}
+}
+```
+
+</Expandable>
+
+---
+
+### `get_current_user`
+
+Get your identity, workspace role, and subscription details. Returns name, email, organization, role, and billing info.
+
+<Expandable title="Parameters">
+  No parameters required.
 </Expandable>
 
 ---
@@ -331,238 +434,166 @@ Tools for writing data to your CRM. Records created via MCP are immediately pick
 
 ### `create_deal`
 
-Create a new opportunity in your pipeline. The deal is automatically picked up by agents - contacts are enriched, the Follow-Up Agent starts monitoring, and activity tracking begins.
+Create a new deal in the CRM and assign it to a pipeline stage. The associated account and contacts must already exist — create them first if needed.
 
 <Expandable title="Parameters">
-  <ParamField body="name" type="string" required>
-    Deal name (e.g., "Stripe - Enterprise Plan").
+  <ParamField body="pipeline_id" type="string" required>
+    Pipeline UUID. Use `get_pipeline_overview` to find it.
   </ParamField>
-  <ParamField body="value" type="number">
-    Deal value in your workspace currency.
+  <ParamField body="name" type="string">
+    Deal name. Auto-generated from account/contact if omitted.
   </ParamField>
-  <ParamField body="stage" type="string">
-    Pipeline stage. Defaults to the first stage in your default pipeline.
+  <ParamField body="stage_id" type="string">
+    Stage UUID within the pipeline. Defaults to first stage. Use `list_pipeline_stages` to find it.
   </ParamField>
-  <ParamField body="company" type="string">
-    Company name or domain. Creates or links to existing company record.
-  </ParamField>
-  <ParamField body="contact_email" type="string">
-    Primary contact email. Creates or links to existing contact.
+  <ParamField body="deal_size" type="number">
+    Deal value in dollars.
   </ParamField>
   <ParamField body="close_date" type="string">
-    Expected close date in ISO 8601 format.
+    Expected close date (ISO 8601).
   </ParamField>
-  <ParamField body="notes" type="string">
-    Initial notes to attach to the deal.
+  <ParamField body="next_action_date" type="string">
+    Next follow-up date (ISO 8601).
+  </ParamField>
+  <ParamField body="next_steps" type="string">
+    Description of next steps for this deal.
+  </ParamField>
+  <ParamField body="account_domain" type="string">
+    Domain of the associated company (must already exist in CRM).
+  </ParamField>
+  <ParamField body="primary_contact_email" type="string">
+    Email of the primary contact (must already exist in CRM).
+  </ParamField>
+  <ParamField body="additional_contact_emails" type="array">
+    Emails of additional contacts (must already exist in CRM).
+  </ParamField>
+  <ParamField body="owner_email" type="string">
+    Email of the deal owner (org member). Defaults to current user.
   </ParamField>
 </Expandable>
 
 <Expandable title="Example">
 
-**Prompt:** "Create a deal for my meeting with Stripe tomorrow - $120K enterprise plan, negotiation stage"
+**Prompt:** "Create a deal for Stripe, $120K enterprise plan"
 
-**Tool call:**
+The AI assistant will chain tools: `get_pipeline_overview` → `create_account` (if needed) → `create_contact` (if needed) → `create_deal`:
+
 ```json
 {
   "tool": "create_deal",
   "arguments": {
+    "pipeline_id": "pipe_abc123",
     "name": "Stripe - Enterprise Plan",
-    "value": 120000,
-    "stage": "Negotiation",
-    "company": "stripe.com",
-    "contact_email": "sarah@stripe.com",
-    "close_date": "2026-04-15"
+    "deal_size": 120000,
+    "account_domain": "stripe.com",
+    "primary_contact_email": "sarah@stripe.com",
+    "close_date": "2026-04-30"
   }
 }
 ```
 
-**What happens next:** Octolane creates the deal, links or creates the company and contact records, enriches the contact with LinkedIn data and job title, enriches the company with size/funding/tech stack, and the Follow-Up Agent starts monitoring the email thread for stale conversations.
+**What happens next:** Octolane creates the deal, enriches linked contacts and accounts, and the Follow-Up Agent starts monitoring the conversation for stale threads.
 
-</Expandable>
-
----
-
-### `update_deal`
-
-Update any field on an existing deal.
-
-<Expandable title="Parameters">
-  <ParamField body="deal_id" type="string" required>
-    The deal ID.
-  </ParamField>
-  <ParamField body="stage" type="string">
-    New pipeline stage.
-  </ParamField>
-  <ParamField body="value" type="number">
-    Updated deal value.
-  </ParamField>
-  <ParamField body="close_date" type="string">
-    Updated close date.
-  </ParamField>
-  <ParamField body="owner" type="string">
-    New deal owner (email).
-  </ParamField>
-  <ParamField body="custom_fields" type="object">
-    Key-value pairs for custom field updates.
-  </ParamField>
 </Expandable>
 
 ---
 
 ### `create_contact`
 
-Create a new contact. Automatically enriched with job title, company, social profiles, and more.
+Create a new contact from an email address. The backend auto-creates the associated account from the email domain and enriches the contact.
 
 <Expandable title="Parameters">
   <ParamField body="email" type="string" required>
-    Contact email address.
+    Contact's email address.
   </ParamField>
-  <ParamField body="name" type="string">
-    Full name.
+  <ParamField body="first_name" type="string">
+    Contact's first name.
   </ParamField>
-  <ParamField body="phone" type="string">
-    Phone number.
+  <ParamField body="last_name" type="string">
+    Contact's last name.
   </ParamField>
-  <ParamField body="company" type="string">
-    Company name or domain.
-  </ParamField>
-  <ParamField body="title" type="string">
-    Job title.
-  </ParamField>
+</Expandable>
+
+<Expandable title="Example">
+
+**Prompt:** "Add Sarah Chen from Stripe to our CRM"
+
+**Tool call:**
+```json
+{
+  "tool": "create_contact",
+  "arguments": {
+    "email": "sarah@stripe.com",
+    "first_name": "Sarah",
+    "last_name": "Chen"
+  }
+}
+```
+
 </Expandable>
 
 ---
 
-### `update_contact`
+### `create_account`
 
-Update fields on an existing contact.
-
-<Expandable title="Parameters">
-  <ParamField body="contact_id" type="string" required>
-    The contact ID.
-  </ParamField>
-  <ParamField body="name" type="string">
-    Updated name.
-  </ParamField>
-  <ParamField body="title" type="string">
-    Updated job title.
-  </ParamField>
-  <ParamField body="phone" type="string">
-    Updated phone number.
-  </ParamField>
-  <ParamField body="custom_fields" type="object">
-    Key-value pairs for custom field updates.
-  </ParamField>
-</Expandable>
-
----
-
-### `create_company`
-
-Create a new company record. Automatically enriched with size, industry, funding, tech stack, and social profiles.
+Create a new account (company) from a domain. Automatically enriched with company info, size, industry, funding, and more.
 
 <Expandable title="Parameters">
   <ParamField body="domain" type="string" required>
-    Company domain (e.g., "stripe.com").
+    Company domain (e.g., "stripe.com", "linear.app").
   </ParamField>
-  <ParamField body="name" type="string">
-    Company name. Auto-detected from domain if omitted.
-  </ParamField>
+</Expandable>
+
+<Expandable title="Example">
+
+**Tool call:**
+```json
+{
+  "tool": "create_account",
+  "arguments": {
+    "domain": "linear.app"
+  }
+}
+```
+
 </Expandable>
 
 ---
 
 ### `create_note`
 
-Attach a note to a deal, contact, or company.
+Create a note and link it to a deal, contact, or account.
 
 <Expandable title="Parameters">
-  <ParamField body="record_id" type="string" required>
-    The ID of the deal, contact, or company.
+  <ParamField body="title" type="string" required>
+    Short title for the note.
   </ParamField>
-  <ParamField body="record_type" type="string" required>
-    Type of record: `deal`, `contact`, `company`.
+  <ParamField body="content" type="string">
+    Full note content (plain text).
   </ParamField>
-  <ParamField body="content" type="string" required>
-    Note content (plain text or markdown).
+  <ParamField body="entity_id" type="string" required>
+    UUID of the entity to link this note to. Use a search tool first to find the ID.
   </ParamField>
-</Expandable>
-
----
-
-## Agent Commands
-
-These tools are the differentiator. No other CRM MCP server gives you access to real-time website visitor intelligence or natural language pipeline queries.
-
-### `get_signal_visitors`
-
-Get companies currently visiting or who recently visited your website, with ICP scoring and page-level data from Signal.
-
-<Expandable title="Parameters">
-  <ParamField body="period" type="string">
-    Time period: `today`, `this_week`, `this_month`. Defaults to `this_week`.
-  </ParamField>
-  <ParamField body="min_icp_score" type="number">
-    Minimum ICP match score (0-100). Filter to high-quality visitors.
-  </ParamField>
-  <ParamField body="page_filter" type="string">
-    Filter by page URL path (e.g., "/pricing" to see visitors on your pricing page).
-  </ParamField>
-  <ParamField body="limit" type="number">
-    Maximum results. Defaults to 20, max 100.
+  <ParamField body="entity_type" type="string" required>
+    Type of the linked entity: `account`, `contact`, or `opportunity`.
   </ParamField>
 </Expandable>
 
 <Expandable title="Example">
 
-**Prompt:** "What companies visited our pricing page this week with an ICP score above 80?"
+**Prompt:** "Add a note to the Stripe deal: spoke with Sarah, they want SOC 2 before signing"
 
-**Tool call:**
+The AI assistant will call `search_deals` first to get the deal ID, then:
+
 ```json
 {
-  "tool": "get_signal_visitors",
+  "tool": "create_note",
   "arguments": {
-    "period": "this_week",
-    "min_icp_score": 80,
-    "page_filter": "/pricing"
+    "title": "Call with Sarah Chen",
+    "content": "Spoke with Sarah - they want SOC 2 report before procurement can sign off. Timeline is end of Q1.",
+    "entity_id": "deal_abc123",
+    "entity_type": "opportunity"
   }
-}
-```
-
-**Response:**
-```json
-{
-  "visitors": [
-    {
-      "company": "Linear",
-      "domain": "linear.app",
-      "icp_score": 94,
-      "employee_count": 120,
-      "industry": "Developer Tools",
-      "funding": "Series B - $52M",
-      "pages_viewed": ["/", "/pricing", "/features", "/pricing"],
-      "total_visits": 4,
-      "first_visit": "2026-03-03T10:22:00Z",
-      "last_visit": "2026-03-07T15:44:00Z",
-      "existing_deal": null,
-      "existing_contacts": []
-    },
-    {
-      "company": "Ramp",
-      "domain": "ramp.com",
-      "icp_score": 87,
-      "employee_count": 800,
-      "industry": "Fintech",
-      "funding": "Series D - $750M",
-      "pages_viewed": ["/pricing", "/vs-hubspot"],
-      "total_visits": 2,
-      "first_visit": "2026-03-05T11:15:00Z",
-      "last_visit": "2026-03-06T09:30:00Z",
-      "existing_deal": null,
-      "existing_contacts": []
-    }
-  ],
-  "total": 2
 }
 ```
 
@@ -570,65 +601,290 @@ Get companies currently visiting or who recently visited your website, with ICP 
 
 ---
 
-### `ask_pipeline`
+### `create_task`
 
-Ask a natural language question about your pipeline and get an instant answer. This tool uses the same AI engine as Octolane's in-app AI Chat.
+Create a task and optionally link it to a deal, contact, or account. Use for reminders, follow-ups, action items, or next steps.
 
 <Expandable title="Parameters">
-  <ParamField body="question" type="string" required>
-    Your question in plain English.
+  <ParamField body="title" type="string" required>
+    Short title for the task.
   </ParamField>
-</Expandable>
-
-<Expandable title="Example questions">
-
-- "Which deals are at risk of going stale?"
-- "What's our pipeline value this quarter vs last quarter?"
-- "How many deals did we close this month?"
-- "Which rep has the most deals in negotiation?"
-- "What's our average deal size by industry?"
-- "Show me deals closing this month that haven't had a meeting in 2 weeks"
-- "What's our win rate for deals over $50K?"
-
+  <ParamField body="content" type="string">
+    Detailed description of the task.
+  </ParamField>
+  <ParamField body="due_date" type="string">
+    Due date (ISO 8601).
+  </ParamField>
+  <ParamField body="priority" type="string">
+    Priority level: `Low`, `Medium`, `High`, or `Urgent`.
+  </ParamField>
+  <ParamField body="is_urgent" type="boolean">
+    Mark as urgent. Defaults to false.
+  </ParamField>
+  <ParamField body="entity_id" type="string">
+    UUID of the entity to link this task to.
+  </ParamField>
+  <ParamField body="entity_type" type="string">
+    Type of the linked entity: `account`, `contact`, or `opportunity`. Required when `entity_id` is provided.
+  </ParamField>
 </Expandable>
 
 <Expandable title="Example">
 
-**Prompt:** "Which deals are at risk?"
+**Prompt:** "Remind me to send SOC 2 report to Stripe by Friday"
 
-**Tool call:**
 ```json
 {
-  "tool": "ask_pipeline",
+  "tool": "create_task",
   "arguments": {
-    "question": "Which deals are at risk of going stale?"
+    "title": "Send SOC 2 report to Stripe",
+    "due_date": "2026-04-17",
+    "priority": "High",
+    "entity_id": "deal_abc123",
+    "entity_type": "opportunity"
   }
 }
 ```
 
-**Response:**
+</Expandable>
+
+---
+
+### `update_deal_stage`
+
+Move a deal to a specific stage by stage ID.
+
+<Expandable title="Parameters">
+  <ParamField body="opportunity_id" type="string" required>
+    The deal/opportunity ID. Use `search_deals` to find it.
+  </ParamField>
+  <ParamField body="stage_id" type="string" required>
+    Target stage ID. Use `list_pipeline_stages` to find available stages.
+  </ParamField>
+</Expandable>
+
+---
+
+### `move_deal_to_next_stage`
+
+Automatically advance a deal to the next stage in its pipeline based on stage order.
+
+<Expandable title="Parameters">
+  <ParamField body="opportunity_id" type="string" required>
+    The deal/opportunity ID. Use `search_deals` to find it.
+  </ParamField>
+</Expandable>
+
+<Expandable title="Example">
+
+**Prompt:** "Move the Stripe deal to the next stage"
+
 ```json
 {
-  "answer": "You have 4 deals at risk of going stale:",
-  "deals": [
-    {
-      "name": "Notion - Annual Contract",
-      "value": 85000,
-      "stage": "Proposal",
-      "days_since_last_activity": 14,
-      "owner": "mike@yourcompany.com",
-      "risk_reason": "No email or meeting activity in 14 days. Last interaction was a proposal sent on Feb 22."
-    },
-    {
-      "name": "Figma - Team Plan",
-      "value": 42000,
-      "stage": "Meeting Scheduled",
-      "days_since_last_activity": 11,
-      "owner": "sarah@yourcompany.com",
-      "risk_reason": "Meeting was scheduled but cancelled. No follow-up sent."
-    }
-  ],
-  "suggestion": "The Follow-Up Agent has drafts ready for 2 of these deals. Check your approval queue."
+  "tool": "move_deal_to_next_stage",
+  "arguments": {
+    "opportunity_id": "deal_abc123"
+  }
+}
+```
+
+</Expandable>
+
+---
+
+### `update_note`
+
+Update an existing note's title or content.
+
+<Expandable title="Parameters">
+  <ParamField body="note_id" type="string" required>
+    UUID of the note to update.
+  </ParamField>
+  <ParamField body="title" type="string">
+    New title for the note.
+  </ParamField>
+  <ParamField body="content" type="string">
+    New content for the note.
+  </ParamField>
+</Expandable>
+
+---
+
+### `update_task`
+
+Update an existing task — change title, due date, priority, or mark as complete.
+
+<Expandable title="Parameters">
+  <ParamField body="task_id" type="string" required>
+    UUID of the task to update.
+  </ParamField>
+  <ParamField body="title" type="string">
+    New title.
+  </ParamField>
+  <ParamField body="content" type="string">
+    New description.
+  </ParamField>
+  <ParamField body="due_date" type="string">
+    New due date (ISO 8601). Set to null to remove.
+  </ParamField>
+  <ParamField body="priority" type="string">
+    New priority: `Low`, `Medium`, `High`, or `Urgent`.
+  </ParamField>
+  <ParamField body="is_urgent" type="boolean">
+    Set or unset urgent flag.
+  </ParamField>
+  <ParamField body="completed" type="boolean">
+    Set to true to mark as done, false to reopen.
+  </ParamField>
+</Expandable>
+
+<Expandable title="Example">
+
+**Prompt:** "Mark my SOC 2 task as done"
+
+```json
+{
+  "tool": "update_task",
+  "arguments": {
+    "task_id": "task_xyz789",
+    "completed": true
+  }
+}
+```
+
+</Expandable>
+
+---
+
+## Pipeline Management
+
+Tools for configuring and navigating your pipeline structure.
+
+### `list_pipeline_stages`
+
+List all stages for a pipeline, showing name, order, type (won/lost/default), and win probability.
+
+<Expandable title="Parameters">
+  <ParamField body="pipeline_name" type="string">
+    Name or partial name of the pipeline. Omit to list stages for all pipelines.
+  </ParamField>
+  <ParamField body="pipeline_id" type="string">
+    Pipeline ID, if already known.
+  </ParamField>
+</Expandable>
+
+---
+
+### `rename_pipeline`
+
+Rename a sales pipeline.
+
+<Expandable title="Parameters">
+  <ParamField body="pipeline_id" type="string" required>
+    UUID of the pipeline to rename. Use `get_pipeline_overview` to find it.
+  </ParamField>
+  <ParamField body="new_name" type="string" required>
+    The new name for the pipeline.
+  </ParamField>
+  <ParamField body="description" type="string">
+    New description for the pipeline.
+  </ParamField>
+</Expandable>
+
+---
+
+## Field Discovery
+
+Tools for discovering available fields and custom properties on your CRM records. Useful before creating or updating records to check what fields are available.
+
+### `get_account_fields`
+
+Discover available fields and custom properties for accounts (companies). Returns field names, types, and valid dropdown options.
+
+<Expandable title="Parameters">
+  No parameters required.
+</Expandable>
+
+---
+
+### `get_contact_fields`
+
+Discover available fields and custom properties for contacts. Returns field names, types, and valid dropdown options.
+
+<Expandable title="Parameters">
+  No parameters required.
+</Expandable>
+
+---
+
+### `get_deal_fields`
+
+Discover available fields and custom properties for deals in a specific pipeline. Each pipeline can have different custom fields.
+
+<Expandable title="Parameters">
+  <ParamField body="pipeline_name" type="string">
+    Name or partial name of the pipeline.
+  </ParamField>
+  <ParamField body="pipeline_id" type="string">
+    Pipeline ID, if already known.
+  </ParamField>
+</Expandable>
+
+---
+
+## Signal
+
+### `get_signal_script`
+
+Get the Octolane Signal tracking script tag for your website. Returns an HTML snippet with your organization's unique public key to install in your website's `<head>`.
+
+<Expandable title="Parameters">
+  No parameters required.
+</Expandable>
+
+---
+
+## Workspace
+
+Tools for managing your workspace and team.
+
+### `list_workspace_members`
+
+List all members in the workspace with their name, email, role, and avatar.
+
+<Expandable title="Parameters">
+  <ParamField body="search_name" type="string">
+    Filter by name to find a specific member.
+  </ParamField>
+</Expandable>
+
+---
+
+### `invite_team_member`
+
+Invite one or more people to your workspace by email. Requires admin or owner role.
+
+<Expandable title="Parameters">
+  <ParamField body="members" type="array" required>
+    List of people to invite (max 10). Each entry has:
+    - `email` (string, required) — email address of the person to invite
+    - `role` (string) — `member` (default), `admin`, or `owner`
+  </ParamField>
+</Expandable>
+
+<Expandable title="Example">
+
+**Prompt:** "Invite sarah@company.com as an admin"
+
+**Tool call:**
+```json
+{
+  "tool": "invite_team_member",
+  "arguments": {
+    "members": [
+      { "email": "sarah@company.com", "role": "admin" }
+    ]
+  }
 }
 ```
 

--- a/mcp/use-with-chatgpt.mdx
+++ b/mcp/use-with-chatgpt.mdx
@@ -87,6 +87,20 @@ Compare our pipeline this quarter to last quarter. Are we ahead
 or behind? Which stages have the biggest changes?
 ```
 
+### Email history
+
+```
+Show me all emails with Acme Corp. When was the last time we
+emailed them and what was it about?
+```
+
+### Task management
+
+```
+What tasks do I have due this week? Mark the "Send proposal"
+task as complete.
+```
+
 ## ChatGPT vs Claude for Octolane
 
 Both work well. A few differences:

--- a/mcp/use-with-claude.mdx
+++ b/mcp/use-with-claude.mdx
@@ -1,126 +1,79 @@
 ---
 title: "Use Octolane with Claude"
 sidebarTitle: "Use with Claude"
-description: "Connect Octolane to Claude Desktop or Claude.ai so you can manage your CRM, query your pipeline, and command your AI sales agents directly from Claude."
+description: "Connect Octolane to Claude.ai as a custom connector so you can manage your CRM, query your pipeline, and command your AI sales agents directly from Claude."
 ---
 
 # Use Octolane with Claude
 
 Claude is the best AI assistant for working with Octolane. It handles multi-step CRM queries naturally, asks clarifying questions when needed, and presents data in clean, readable formats.
 
-## Claude Desktop setup
+<Note>
+Claude.ai custom connectors currently only work in the **web version** ([claude.ai](https://claude.ai)) — not Claude Desktop. Make sure you're set up on the web before you start.
+</Note>
+
+## Setup
 
 <Steps>
 
-<Step title="Open your config file">
+<Step title="Open Claude in your browser">
 
-Find your Claude Desktop configuration file:
-
-| OS | Path |
-|-----|------|
-| Mac | `~/Library/Application Support/Claude/claude_desktop_config.json` |
-| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
-| Linux | `~/.config/Claude/claude_desktop_config.json` |
-
-Create the file if it doesn't exist.
+Go to [claude.ai](https://claude.ai) and sign in. Custom connectors are only available in the web app today, so this step won't work from Claude Desktop.
 
 </Step>
 
-<Step title="Add the Octolane MCP server">
+<Step title="Open Settings → Connectors">
 
-Paste this configuration (replace `your-api-key` with your actual key from **Settings > Integrations > API**):
+Click your profile icon in the bottom-left corner, open **Settings**, and switch to the **Connectors** tab. Scroll to the bottom of the connector list and click **Add custom connector**.
 
-```json
-{
-  "mcpServers": {
-    "octolane": {
-      "url": "https://mcp.octolane.com/mcp",
-      "headers": {
-        "X-API-Key": "your-api-key"
-      }
-    }
-  }
-}
+</Step>
+
+<Step title="Paste your Octolane MCP server URL">
+
+Name the connector **Octolane** (or anything you like). Paste this link into the URL field:
+
+```
+https://mcp.octolane.com/mcp
 ```
 
-If you already have other MCP servers configured, add the `"octolane"` entry inside the existing `"mcpServers"` object.
+Then click **Connect**.
 
 </Step>
 
-<Step title="Restart Claude Desktop">
+<Step title="Add your Octolane MCP API key">
 
-Quit Claude Desktop completely and reopen it. You should see the Octolane tools available in the tools panel.
+You'll need a free Octolane account. Grab your MCP API key from [octolane.com/settings/mcp](https://www.octolane.com/settings/mcp) and paste it into the connector when prompted.
+
+</Step>
+
+<Step title="Enable the connector in a conversation">
+
+Connectors are enabled per-conversation. In the chat input, click the **+** button (bottom-left), open **Connectors**, and toggle **Octolane** on. You're good to go — try asking a question from the examples below.
 
 </Step>
 
 </Steps>
 
-## Claude.ai setup
-
-In Claude.ai, go to **Settings > MCP Servers > Add Server** and enter:
-
-- **Name:** Octolane
-- **URL:** `https://mcp.octolane.com/mcp`
-- **Headers:** `X-API-Key: your-api-key`
-
-The Octolane tools are available immediately in your next conversation.
-
 ## Example prompts
 
 Here are prompts that work well with Claude + Octolane. Copy and paste any of these to get started.
 
-### Pipeline review
+### Pipeline summary
 
 ```
-Show me all open deals. For each one, tell me the stage, value, owner,
-and how many days since the last activity. Flag any that look stale.
+What's my pipeline summary on Octolane?
 ```
 
-### Website visitor intelligence
+### Deal deep-dive
 
 ```
-What companies visited our pricing page this week? Show me the ones
-that match our ICP, sorted by match score. Include company size and
-industry for each.
+Can you tell me about the Acme deal?
 ```
 
-### Meeting prep
+### Draft a follow-up
 
 ```
-I have a call with Stripe tomorrow. Pull up everything we know about
-them - the deal status, all contacts we've talked to, recent email
-activity, and any action items from past meetings.
-```
-
-### Deal creation
-
-```
-Create a deal for my meeting with Notion next Tuesday. It's a $85K
-annual contract, they're at the proposal stage. Main contact is
-sarah@notion.so.
-```
-
-### Pipeline analytics
-
-```
-What's our pipeline value this quarter compared to last quarter?
-Break it down by stage. Which deals are most likely to close this month?
-```
-
-### Lead qualification
-
-```
-A new lead just came in - john@linearapp.com. What do we know about
-their company? How do they score against our ICP? Do we have any
-existing contacts or deals with them?
-```
-
-### Stale deal sweep
-
-```
-Show me all deals that haven't had any activity in the last 2 weeks.
-For each one, tell me who owns it, what stage it's in, and when the
-last email or meeting was.
+Write me a follow-up email for the Acme deal for our next meeting.
 ```
 
 ## Tips for best results

--- a/mcp/use-with-cursor.mdx
+++ b/mcp/use-with-cursor.mdx
@@ -151,8 +151,18 @@ Decision in 2 weeks."
 <Accordion title="End-of-day deal update">
 
 ```
-Update the Stripe deal: move to Negotiation stage, update value
-to $150K (they want to add 20 more seats). Close date is April 30.
+Move the Stripe deal to the Negotiation stage. Also add a note:
+"They want to add 20 more seats, new value ~$150K. Close date
+pushed to April 30."
+```
+
+</Accordion>
+
+<Accordion title="Task and email check">
+
+```
+What tasks do I have due today? And show me any unanswered
+emails from this week.
 ```
 
 </Accordion>

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -30,5 +30,5 @@ Expected time: **5 minutes**. No admin needed.
   </Card>
 </CardGroup>
 
-Need a hand? [support@octolane.com](mailto:support@octolane.com)
+Need a hand? [help@octolane.com](mailto:help@octolane.com)
 

--- a/support.mdx
+++ b/support.mdx
@@ -7,7 +7,7 @@ description: "How to get help from Octolane"
 
 ## How to reach us
 
-- Email: [support@octolane.com](mailto:support@octolane.com)  
+- Email: [help@octolane.com](mailto:help@octolane.com)  
 - Security issues: [security@octolane.com](mailto:security@octolane.com)  
 - Schedule a call/demo: [octolane.com](https://octolane.com)
 

--- a/support/contact.mdx
+++ b/support/contact.mdx
@@ -10,8 +10,8 @@ We're a small team that moves fast. If you need help, you'll talk to someone who
 
 <CardGroup cols={2}>
 
-<Card title="Email Us" icon="envelope" href="mailto:support@octolane.com">
-  **support@octolane.com**
+<Card title="Email Us" icon="envelope" href="mailto:help@octolane.com">
+  **help@octolane.com**
 
   We respond within a few hours during business hours (9am–6pm PT, Mon–Fri). For urgent issues, email one@octolane.com directly.
 </Card>
@@ -67,7 +67,7 @@ Make sure your email account is connected and showing as active in **Settings �
 </Accordion>
 
 <Accordion title="I need to change my plan or billing info">
-Go to **Settings → Billing** to upgrade, downgrade, or update your payment method. If you need help with invoicing or have a billing question, email support@octolane.com.
+Go to **Settings → Billing** to upgrade, downgrade, or update your payment method. If you need help with invoicing or have a billing question, email help@octolane.com.
 </Accordion>
 
 </AccordionGroup>


### PR DESCRIPTION
- Rewrite use-with-claude for Claude.ai web custom connector flow (Desktop not supported)
- Trim Claude example prompts to 3 focused queries (pipeline summary, deal deep-dive, follow-up)
- Promote rich Card-based welcome layout to root (/) so it matches /get-started/welcome
- Replace support@octolane.com with help@octolane.com across all docs
- Refresh MCP overview, quickstart, tools reference, examples, authentication, and other client guides

Made-with: Cursor