### PR TITLE
Add read & search API: list and search Accounts, Contacts, Opportunities

### DIFF
--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -1,10 +1,10 @@
 ---
 title: "API Reference"
 sidebarTitle: "Introduction"
-description: "Push data into Octolane via the Inbound API - create opportunities, accounts, contacts, and notes with simple API calls."
+description: "Push data into Octolane and read your CRM with simple REST calls - opportunities, accounts, contacts, and notes."
 ---
 
-The Octolane Inbound API lets you push data into your CRM from any source - your outbound tools, marketing platforms, custom scripts, or internal systems. Create opportunities, accounts, contacts, and notes with simple REST calls.
+The Octolane API lets you push data into your CRM from any source - your outbound tools, marketing platforms, custom scripts, internal systems - and read it back with full filtering and search. Create and read opportunities, accounts, contacts, and notes with simple REST calls.
 
 ## Base URL
 

--- a/api-reference/v2/filters.mdx
+++ b/api-reference/v2/filters.mdx
@@ -1,0 +1,106 @@
+---
+title: "Filters"
+sidebarTitle: "Filters"
+description: "Operator reference and aliases for search endpoints."
+---
+
+Filters are supported on every `POST .../search` endpoint:
+
+- [`POST /accounts/search`](/api-reference/v2/search-accounts)
+- [`POST /contacts/search`](/api-reference/v2/search-contacts)
+- [`POST /opportunities/search`](/api-reference/v2/search-opportunities)
+
+## Filter shape
+
+Each filter is an object with `field`, `operator`, and `value`.
+
+```json
+{
+  "filters": [
+    { "field": "customer_tier", "operator": "eq", "value": "enterprise" },
+    { "field": "amount", "operator": "gte", "value": 50000 }
+  ]
+}
+```
+
+Multiple filters in the array combine with **AND**.
+
+## Supported operators
+
+| Operator | Use |
+|---|---|
+| `eq` | Equal |
+| `neq` | Not equal |
+| `contains` | String contains substring |
+| `not_contains` | String does not contain substring |
+| `starts_with` | String starts with |
+| `ends_with` | String ends with |
+| `in` | Value is in array |
+| `not_in` | Value is not in array |
+| `gt` | Greater than |
+| `gte` | Greater than or equal |
+| `lt` | Less than |
+| `lte` | Less than or equal |
+| `between` | Between two values (inclusive). Pass `value` as `[min, max]` |
+| `empty` | Field has no value |
+| `not_empty` | Field has any value |
+| `contains_all` | Array field contains all of the given values |
+| `contains_none` | Array field contains none of the given values |
+
+## Operator aliases
+
+These read more naturally and resolve to the same operator under the hood.
+
+| Alias | Resolves to |
+|---|---|
+| `is` | `eq` |
+| `is_not` | `neq` |
+| `contain` | `contains` |
+| `not_contain` | `not_contains` |
+| `is_any_of` | `in` |
+| `greater_than` | `gt` |
+| `less_than` | `lt` |
+| `before` | `lt` |
+| `after` | `gt` |
+| `include_all` | `contains_all` |
+| `exclude_all` | `contains_none` |
+
+## Custom field filters
+
+Custom fields are filtered by their slug (the same key returned in `custom_fields`).
+
+```json
+{
+  "filters": [
+    { "field": "customer_tier", "operator": "eq", "value": "enterprise" }
+  ]
+}
+```
+
+Look up slugs in the `custom_field_definitions` block of any response.
+
+## Examples
+
+### Range filter
+
+```json
+{ "field": "amount", "operator": "between", "value": [10000, 50000] }
+```
+
+### Array membership
+
+```json
+{ "field": "industry", "operator": "in", "value": ["Software", "Fintech"] }
+```
+
+### Date after
+
+```json
+{ "field": "close_date", "operator": "after", "value": "2026-06-01" }
+```
+
+### Empty check
+
+```json
+{ "field": "next_action_date", "operator": "empty" }
+```

--- a/api-reference/v2/list-accounts.mdx
+++ b/api-reference/v2/list-accounts.mdx
@@ -1,0 +1,88 @@
+---
+title: "List accounts"
+sidebarTitle: "List accounts"
+description: "Simple account list with basic text search and cursor pagination."
+api: "GET https://enrich.octolane.com/v2/inbound/accounts"
+---
+
+Simple list endpoint for Accounts with basic text search and cursor pagination.
+
+<Note>Filters and sorting are **not supported** on this endpoint. Use [`POST /accounts/search`](/api-reference/v2/search-accounts) when you need them.</Note>
+
+## Request
+
+<ParamField header="X-API-Key" type="string" required>
+  Your Octolane API key.
+</ParamField>
+
+### Query parameters
+
+<ParamField query="q" type="string">
+  Basic text search across account name and domain.
+</ParamField>
+
+<ParamField query="cursor" type="string">
+  Opaque cursor from a previous response. See [Cursor pagination](/api-reference/v2/pagination).
+</ParamField>
+
+<ParamField query="limit" type="number" default="100">
+  Page size. Max `500`.
+</ParamField>
+
+<ParamField query="fields" type="string">
+  Comma-separated fields or JSON-encoded string array.
+</ParamField>
+
+## Example request
+
+```bash
+curl "https://enrich.octolane.com/v2/inbound/accounts?limit=10&q=acme&fields=id,name,domain,custom_fields" \
+  -H "X-API-Key: your-api-key"
+```
+
+## Response fields
+
+### Common fields
+
+`id`, `name`, `domain`, `logo`, `created_at`, `updated_at`, `first_interaction`, `last_interaction`, `custom_fields`
+
+### Additional system fields
+
+`industry`, `tags`, `linkedin`, `twitter`, `description`, `primary_location`, `founded`, `estimated_revenue`, `employee_range`, `type`, `next_meeting`
+
+## Example response
+
+```json 200
+{
+  "success": true,
+  "requestId": "req-id",
+  "data": {
+    "accounts": [
+      {
+        "id": "f3e0cab5-1c28-4fca-8fdf-7f555afbe967",
+        "name": "Acme Inc",
+        "domain": "acme.com",
+        "industry": "Software",
+        "created_at": "2026-05-01T10:00:00.000Z",
+        "updated_at": "2026-05-25T09:30:03.285Z",
+        "custom_fields": {
+          "customer_tier": "enterprise"
+        }
+      }
+    ],
+    "custom_field_definitions": {
+      "customer_tier": {
+        "current_name": "Customer Tier",
+        "property_name": "select_530",
+        "attribute_type": "select",
+        "metadata": null
+      }
+    },
+    "has_more": true,
+    "next_cursor": "opaque_cursor_token",
+    "limit": 10
+  },
+  "message": "Accounts fetched successfully",
+  "statusCode": 200
+}
+```

--- a/api-reference/v2/list-contacts.mdx
+++ b/api-reference/v2/list-contacts.mdx
@@ -1,0 +1,80 @@
+---
+title: "List contacts"
+sidebarTitle: "List contacts"
+description: "Simple contact list with basic text search and cursor pagination."
+api: "GET https://enrich.octolane.com/v2/inbound/contacts"
+---
+
+Simple list endpoint for Contacts.
+
+<Note>Filters and sorting are **not supported** on this endpoint. Use [`POST /contacts/search`](/api-reference/v2/search-contacts) when you need them.</Note>
+
+## Request
+
+<ParamField header="X-API-Key" type="string" required>
+  Your Octolane API key.
+</ParamField>
+
+### Query parameters
+
+<ParamField query="q" type="string">
+  Basic text search across contact name and email.
+</ParamField>
+
+<ParamField query="cursor" type="string">
+  Opaque cursor from a previous response. See [Cursor pagination](/api-reference/v2/pagination).
+</ParamField>
+
+<ParamField query="limit" type="number" default="100">
+  Page size. Max `500`.
+</ParamField>
+
+<ParamField query="fields" type="string">
+  Comma-separated fields or JSON-encoded string array.
+</ParamField>
+
+## Example request
+
+```bash
+curl "https://enrich.octolane.com/v2/inbound/contacts?limit=10&q=john&fields=id,name,email,job_title,custom_fields" \
+  -H "X-API-Key: your-api-key"
+```
+
+## Example response
+
+```json 200
+{
+  "success": true,
+  "data": {
+    "contacts": [
+      {
+        "id": "contact_uuid",
+        "name": "John Smith",
+        "first_name": "John",
+        "last_name": "Smith",
+        "email": "john@example.com",
+        "avatar_url": null,
+        "account_id": "account_uuid",
+        "created_at": "2026-05-25T09:30:03.285099Z",
+        "updated_at": "2026-05-25T09:30:03.285099Z",
+        "custom_fields": {
+          "customer_tier": "enterprise"
+        }
+      }
+    ],
+    "custom_field_definitions": {
+      "customer_tier": {
+        "current_name": "Customer Tier",
+        "property_name": "text_123",
+        "attribute_type": "string",
+        "metadata": null
+      }
+    },
+    "has_more": true,
+    "next_cursor": "opaque_cursor",
+    "limit": 10
+  },
+  "message": "Contacts fetched successfully",
+  "statusCode": 200
+}
+```

--- a/api-reference/v2/list-opportunities.mdx
+++ b/api-reference/v2/list-opportunities.mdx
@@ -1,0 +1,100 @@
+---
+title: "List opportunities"
+sidebarTitle: "List opportunities"
+description: "Simple opportunity list scoped to a pipeline, with cursor pagination and basic text search."
+api: "GET https://enrich.octolane.com/v2/inbound/opportunities"
+---
+
+Simple list endpoint for Opportunities.
+
+<Note>`pipeline_id` is **mandatory**. Filters and sorting are not supported. Use [`POST /opportunities/search`](/api-reference/v2/search-opportunities) when you need them.</Note>
+
+## Request
+
+<ParamField header="X-API-Key" type="string" required>
+  Your Octolane API key.
+</ParamField>
+
+### Query parameters
+
+<ParamField query="pipeline_id" type="string" required>
+  Pipeline UUID.
+</ParamField>
+
+<ParamField query="stage_id" type="string">
+  Filter opportunities by stage.
+</ParamField>
+
+<ParamField query="q" type="string">
+  Basic text search across opportunity name, next steps, account, and contact email.
+</ParamField>
+
+<ParamField query="cursor" type="string">
+  Opaque cursor from a previous response.
+</ParamField>
+
+<ParamField query="limit" type="number" default="100">
+  Page size. Max `500`.
+</ParamField>
+
+<ParamField query="fields" type="string">
+  Comma-separated fields or JSON-encoded string array.
+</ParamField>
+
+## Example request
+
+```bash
+curl "https://enrich.octolane.com/v2/inbound/opportunities?pipeline_id=pipeline_uuid&stage_id=stage_uuid&limit=10&q=renewal" \
+  -H "X-API-Key: your-api-key"
+```
+
+## Example response
+
+```json 200
+{
+  "success": true,
+  "data": {
+    "opportunities": [
+      {
+        "id": "opportunity_uuid",
+        "name": "Enterprise Renewal",
+        "pipeline_id": "pipeline_uuid",
+        "stage_id": "stage_uuid",
+        "stage_name": "Qualification",
+        "amount": 50000,
+        "probability": 40,
+        "close_date": "2026-06-30T00:00:00.000Z",
+        "next_action_date": null,
+        "next_steps": "Follow up with buyer",
+        "owner_id": "user_uuid",
+        "account_id": "account_uuid",
+        "account_name": "Example Inc",
+        "account_domain": "example.com",
+        "contact_id": "contact_uuid",
+        "contact_first_name": "John",
+        "contact_last_name": "Smith",
+        "contact_email": "john@example.com",
+        "additional_contacts": [],
+        "created_at": "2026-05-25T09:30:03.285099Z",
+        "updated_at": "2026-05-25T09:30:03.285099Z",
+        "custom_fields": {
+          "deal_source": "partner"
+        }
+      }
+    ],
+    "custom_field_definitions": {
+      "deal_source": {
+        "current_name": "Deal Source",
+        "property_name": "select_456",
+        "attribute_type": "select",
+        "metadata": { "select_options": [] }
+      }
+    },
+    "has_more": true,
+    "next_cursor": "opaque_cursor",
+    "limit": 10
+  },
+  "message": "Opportunities fetched successfully",
+  "statusCode": 200
+}
+```

--- a/api-reference/v2/overview.mdx
+++ b/api-reference/v2/overview.mdx
@@ -1,0 +1,81 @@
+---
+title: "Read & search"
+sidebarTitle: "Overview"
+description: "Read APIs for Accounts, Contacts, and Opportunities with filters, sorting, field selection, and cursor pagination."
+---
+
+Read access to your Octolane CRM. Each object (Accounts, Contacts, Opportunities) has two endpoints:
+
+- A **simple list endpoint** (`GET`) with basic text search and cursor pagination.
+- A **search endpoint** (`POST`) with full filtering, sorting, field selection, and cursor pagination.
+
+## Base URL
+
+```
+https://enrich.octolane.com/v2/inbound
+```
+
+## Authentication
+
+Every request must include the API key in the `X-API-Key` header.
+
+```
+X-API-Key: your-api-key
+```
+
+Find your API key in **Settings , Integrations , API**.
+
+## Endpoints
+
+| Object | List | Search |
+|---|---|---|
+| Accounts | [`GET /accounts`](/api-reference/v2/list-accounts) | [`POST /accounts/search`](/api-reference/v2/search-accounts) |
+| Contacts | [`GET /contacts`](/api-reference/v2/list-contacts) | [`POST /contacts/search`](/api-reference/v2/search-contacts) |
+| Opportunities | [`GET /opportunities`](/api-reference/v2/list-opportunities) | [`POST /opportunities/search`](/api-reference/v2/search-opportunities) |
+
+## Shared concepts
+
+<CardGroup cols={2}>
+  <Card title="Filters" icon="filter" href="/api-reference/v2/filters">
+    Operator reference and aliases used in every `POST .../search` endpoint.
+  </Card>
+  <Card title="Cursor pagination" icon="arrow-right" href="/api-reference/v2/pagination">
+    How to paginate `GET` and `POST` endpoints safely.
+  </Card>
+</CardGroup>
+
+## Field selection
+
+Every list and search endpoint accepts a `fields` parameter to return only the fields you need. Pass a comma-separated string (for `GET`) or a JSON array (for `POST`).
+
+```
+GET  /accounts?fields=id,name,domain,custom_fields
+POST /accounts/search   { "fields": ["id", "name", "domain", "custom_fields"] }
+```
+
+## Custom fields
+
+Every response includes a `custom_fields` object on each record and a top-level `custom_field_definitions` object describing those fields.
+
+```json
+{
+  "custom_fields": {
+    "customer_tier": "enterprise",
+    "renewal_date": "2026-06-01T00:00:00.000Z"
+  },
+  "custom_field_definitions": {
+    "customer_tier": {
+      "current_name": "Customer Tier",
+      "property_name": "select_530",
+      "attribute_type": "select",
+      "metadata": { "select_options": [] }
+    }
+  }
+}
+```
+
+The keys in `custom_field_definitions` match the keys in `custom_fields`, so clients can resolve slug/value mappings dynamically.
+
+## Need help?
+
+Email [one@octolane.com](mailto:one@octolane.com). We ship custom endpoints when teams need something specific.

--- a/api-reference/v2/pagination.mdx
+++ b/api-reference/v2/pagination.mdx
@@ -1,0 +1,68 @@
+---
+title: "Cursor pagination"
+sidebarTitle: "Cursor pagination"
+description: "How to paginate list and search endpoints."
+---
+
+Every list and search response includes:
+
+```json
+{
+  "has_more": true,
+  "next_cursor": "opaque_cursor_token",
+  "limit": 10
+}
+```
+
+Continue paginating until:
+
+```json
+{ "has_more": false, "next_cursor": null }
+```
+
+## GET endpoints
+
+Pass `cursor` as a query parameter.
+
+### First request
+
+```bash
+curl "https://enrich.octolane.com/v2/inbound/accounts?limit=10" \
+  -H "X-API-Key: your-api-key"
+```
+
+### Next request
+
+```bash
+curl "https://enrich.octolane.com/v2/inbound/accounts?limit=10&cursor=<next_cursor>" \
+  -H "X-API-Key: your-api-key"
+```
+
+## POST search endpoints
+
+Pass `cursor` in the request body. Keep `filters`, `sort`, `limit`, and (for opportunities) `pipeline_id`/`stage_id` identical between pages.
+
+### First request
+
+```json
+{
+  "pipeline_id": "pipeline_uuid",
+  "limit": 10,
+  "sort": { "field": "updated_at", "direction": "desc" }
+}
+```
+
+### Next request
+
+```json
+{
+  "pipeline_id": "pipeline_uuid",
+  "limit": 10,
+  "sort": { "field": "updated_at", "direction": "desc" },
+  "cursor": "next_cursor_from_previous_response"
+}
+```
+
+<Warning>
+  Cursors are valid only when paired with the **same query**: `query`, `filters`, `sort`, `limit`, and (for opportunities) `pipeline_id` / `stage_id`. Changing any of these invalidates the cursor.
+</Warning>

--- a/api-reference/v2/search-accounts.mdx
+++ b/api-reference/v2/search-accounts.mdx
@@ -1,0 +1,109 @@
+---
+title: "Search accounts"
+sidebarTitle: "Search accounts"
+description: "Advanced account search with filters, sorting, pagination, and field selection."
+api: "POST https://enrich.octolane.com/v2/inbound/accounts/search"
+---
+
+Advanced search endpoint for Accounts. Supports filters on system and custom fields, sorting, cursor pagination, and field selection.
+
+## Request
+
+<ParamField header="X-API-Key" type="string" required>
+  Your Octolane API key.
+</ParamField>
+
+<ParamField header="Content-Type" type="string" required>
+  Must be `application/json`.
+</ParamField>
+
+### Body parameters
+
+<ParamField body="query" type="string">
+  Basic text search across account name and domain. Alias: `q`.
+</ParamField>
+
+<ParamField body="filters" type="array">
+  Array of filter objects. See [Filters](/api-reference/v2/filters) for operators and aliases.
+</ParamField>
+
+<ParamField body="sort" type="string | object | array">
+  Sort configuration. See [Sorting](#sorting) below.
+</ParamField>
+
+<ParamField body="cursor" type="string">
+  Opaque cursor from a previous response. See [Cursor pagination](/api-reference/v2/pagination).
+</ParamField>
+
+<ParamField body="limit" type="number" default="100">
+  Page size. Max `500`.
+</ParamField>
+
+<ParamField body="fields" type="string[]">
+  Fields to return. If omitted, all common fields are returned.
+</ParamField>
+
+## Example request
+
+```bash
+curl -X POST "https://enrich.octolane.com/v2/inbound/accounts/search" \
+  -H "X-API-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "acme",
+    "filters": [
+      {
+        "field": "customer_tier",
+        "operator": "eq",
+        "value": "enterprise"
+      }
+    ],
+    "sort": { "field": "updated_at", "direction": "desc" },
+    "limit": 10,
+    "fields": ["id", "name", "domain", "industry", "custom_fields"]
+  }'
+```
+
+## Sorting
+
+### String format
+
+```json
+{ "sort": "updated_at:desc" }
+```
+
+### Object format
+
+```json
+{ "sort": { "field": "created_at", "direction": "asc" } }
+```
+
+### Supported sort fields
+
+`updated_at`, `created_at`, `name`, `domain`, `id`
+
+### Default sort
+
+`updated_at desc`
+
+## Filters
+
+See [Filters](/api-reference/v2/filters) for the full operator reference and aliases.
+
+### Custom field example
+
+```json
+{
+  "filters": [
+    {
+      "field": "customer_tier",
+      "operator": "eq",
+      "value": "enterprise"
+    }
+  ]
+}
+```
+
+## Response
+
+Identical shape to [`GET /accounts`](/api-reference/v2/list-accounts#example-response). Pass `next_cursor` back in the body to fetch the next page. Keep `filters`, `sort`, and `limit` the same across pages.

--- a/api-reference/v2/search-contacts.mdx
+++ b/api-reference/v2/search-contacts.mdx
@@ -1,0 +1,70 @@
+---
+title: "Search contacts"
+sidebarTitle: "Search contacts"
+description: "Advanced contact search with filters, sorting, pagination, and field selection."
+api: "POST https://enrich.octolane.com/v2/inbound/contacts/search"
+---
+
+Advanced search endpoint for Contacts. Supports filters on system and custom fields, sorting, cursor pagination, and field selection.
+
+## Request
+
+<ParamField header="X-API-Key" type="string" required>
+  Your Octolane API key.
+</ParamField>
+
+<ParamField header="Content-Type" type="string" required>
+  Must be `application/json`.
+</ParamField>
+
+### Body parameters
+
+<ParamField body="query" type="string">
+  Basic text search across name and email. Alias: `q`.
+</ParamField>
+
+<ParamField body="filters" type="array">
+  Array of filter objects. See [Filters](/api-reference/v2/filters).
+</ParamField>
+
+<ParamField body="sort" type="string | object | array">
+  Sort configuration. Default: `updated_at desc`.
+</ParamField>
+
+<ParamField body="cursor" type="string">
+  Opaque cursor from a previous response.
+</ParamField>
+
+<ParamField body="limit" type="number" default="100">
+  Page size. Max `500`.
+</ParamField>
+
+<ParamField body="fields" type="string[]">
+  Fields to return.
+</ParamField>
+
+## Example request
+
+```bash
+curl -X POST "https://enrich.octolane.com/v2/inbound/contacts/search" \
+  -H "X-API-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "limit": 10,
+    "q": "john",
+    "filters": [
+      { "field": "email", "operator": "contains", "value": "@example.com" },
+      { "field": "customer_tier", "operator": "eq", "value": "enterprise" }
+    ],
+    "sort": { "field": "updated_at", "direction": "desc" },
+    "fields": ["id", "name", "email", "job_title", "custom_fields"]
+  }'
+```
+
+## Supported sort fields
+
+`updated_at`, `created_at`, `name`, `first_name`, `last_name`, `email`, `account_id`, `id`
+
+## Response
+
+Identical shape to [`GET /contacts`](/api-reference/v2/list-contacts#example-response).

--- a/api-reference/v2/search-opportunities.mdx
+++ b/api-reference/v2/search-opportunities.mdx
@@ -1,0 +1,84 @@
+---
+title: "Search opportunities"
+sidebarTitle: "Search opportunities"
+description: "Advanced opportunity search with filters, sorting, pagination, and field selection."
+api: "POST https://enrich.octolane.com/v2/inbound/opportunities/search"
+---
+
+Advanced search endpoint for Opportunities. Supports filters on system and custom fields, sorting, cursor pagination, and field selection.
+
+<Note>`pipeline_id` is **mandatory**.</Note>
+
+## Request
+
+<ParamField header="X-API-Key" type="string" required>
+  Your Octolane API key.
+</ParamField>
+
+<ParamField header="Content-Type" type="string" required>
+  Must be `application/json`.
+</ParamField>
+
+### Body parameters
+
+<ParamField body="pipeline_id" type="string" required>
+  Pipeline UUID.
+</ParamField>
+
+<ParamField body="stage_id" type="string">
+  Filter opportunities by stage.
+</ParamField>
+
+<ParamField body="query" type="string">
+  Basic text search. Alias: `q`.
+</ParamField>
+
+<ParamField body="filters" type="array">
+  Array of filter objects. See [Filters](/api-reference/v2/filters).
+</ParamField>
+
+<ParamField body="sort" type="string | object | array">
+  Sort configuration. Default: `updated_at desc`.
+</ParamField>
+
+<ParamField body="cursor" type="string">
+  Opaque cursor from a previous response.
+</ParamField>
+
+<ParamField body="limit" type="number" default="100">
+  Page size. Max `500`.
+</ParamField>
+
+<ParamField body="fields" type="string[]">
+  Fields to return.
+</ParamField>
+
+## Example request
+
+```bash
+curl -X POST "https://enrich.octolane.com/v2/inbound/opportunities/search" \
+  -H "X-API-Key: your-api-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "pipeline_id": "pipeline_uuid",
+    "stage_id": "stage_uuid",
+    "limit": 10,
+    "filters": [
+      { "field": "amount", "operator": "gte", "value": 50000 },
+      { "field": "deal_source", "operator": "eq", "value": "partner" }
+    ],
+    "sort": { "field": "updated_at", "direction": "desc" },
+    "fields": [
+      "id", "name", "stage_id", "stage_name", "amount",
+      "account_id", "contact_id", "custom_fields"
+    ]
+  }'
+```
+
+## Supported sort fields
+
+`updated_at`, `created_at`, `name`, `amount`, `probability`, `close_date`, `next_action_date`, `stage_id`, `owner_id`, `id`
+
+## Response
+
+Identical shape to [`GET /opportunities`](/api-reference/v2/list-opportunities#example-response).

--- a/docs.json
+++ b/docs.json
@@ -213,13 +213,32 @@
         "icon": "square-terminal",
         "groups": [
           {
-            "group": "API Reference",
+            "group": "Getting started",
             "pages": [
-              "api-reference/introduction",
+              "api-reference/introduction"
+            ]
+          },
+          {
+            "group": "Create",
+            "pages": [
               "api-reference/create-opportunity",
               "api-reference/create-account",
               "api-reference/create-contact",
               "api-reference/create-note"
+            ]
+          },
+          {
+            "group": "Read & search",
+            "pages": [
+              "api-reference/v2/overview",
+              "api-reference/v2/list-accounts",
+              "api-reference/v2/search-accounts",
+              "api-reference/v2/list-contacts",
+              "api-reference/v2/search-contacts",
+              "api-reference/v2/list-opportunities",
+              "api-reference/v2/search-opportunities",
+              "api-reference/v2/filters",
+              "api-reference/v2/pagination"
             ]
           }
         ]


### PR DESCRIPTION
- 8 new pages under api-reference/v2/: overview, list+search for Accounts/Contacts/Opportunities, plus shared Filters and Pagination
- Sidebar restructured into 3 groups: Getting started, Create, Read & search
- Renamed groups to drop version/Inbound jargon (no V1/V2 in nav)
- Updated api-reference introduction to cover both write and read