### PR TITLE
docs: fix footer social links & clarify Create account lookup-by-domain

### DIFF
--- a/api-reference/endpoints/crm/create-or-resolve-an-account.mdx
+++ b/api-reference/endpoints/crm/create-or-resolve-an-account.mdx
@@ -1,3 +1,9 @@
 ---
 openapi: post /v1/accounts
 ---
+
+<Note>
+  **Also use this to look up an account by domain.** This endpoint is idempotent — if an account with the given `domain` already exists, it returns that existing account instead of creating a duplicate. So sending a `POST` with just a `domain` is a safe way to *resolve or fetch* an account by its domain.
+
+  Need to find accounts by other criteria, or match many at once? Use [Search accounts](/api-reference/endpoints/crm/search-accounts) for filtered search.
+</Note>

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -1338,4 +1338,4 @@ rss: true
   - Action preview shows exactly what will happen when you approve
 </Update>
 
-Follow us on [X (Twitter)](https://twitter.com/octolane_ai) and [LinkedIn](https://linkedin.com/company/octolane) for real-time announcements.
+Follow us on [X](https://x.com/octolane) and [LinkedIn](https://www.linkedin.com/company/octolane) for real-time announcements.

--- a/docs.json
+++ b/docs.json
@@ -315,7 +315,8 @@
       }
     ],
     "socials": {
-      "x": "https://twitter.com/octolane_ai",
+      "x": "https://x.com/octolane",
+      "linkedin": "https://www.linkedin.com/company/octolane",
       "website": "https://www.octolane.com"
     }
   },


### PR DESCRIPTION
Follow-ups to #25 (squash-merged, so these two changes weren't included).

## Footer social links
- **X:** `https://twitter.com/octolane_ai` → `https://x.com/octolane`
- **LinkedIn:** added `https://www.linkedin.com/company/octolane` (was missing)
- Applied in both `docs.json` (`footer.socials`) and the changelog footer line.

## Create account: clarify look-up-by-domain
The `POST /v1/accounts` endpoint is idempotent — if the `domain` already exists it returns the existing account. Added a callout on the **Create account** page making it clear this can be used to *resolve / look up an account by domain*, with a link to **Search accounts** for filtered queries.

## Verification
- Footer links render with correct URLs.
- Create account callout verified rendering in-browser (note text + Search accounts link present), placed under the `POST /v1/accounts` bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)