### PR TITLE
Make pipeline_id optional in opportunities search API

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -903,10 +903,10 @@
         ],
         "operationId": "searchOpportunitiesV1Compatibility",
         "summary": "Search opportunities",
-        "description": "Search opportunities in a required pipeline with optional stage, structured filters, sort, cursor pagination, and field projection. Custom attribute names and value types are returned in `data.custom_field_definitions`; keys in that map match keys under each opportunity's `custom_fields` object.",
+        "description": "Search opportunities with optional pipeline scope, stage, structured filters, sort, cursor pagination, and field projection. `pipeline_id` is optional; when omitted the search spans every pipeline in the org. Custom attribute names and value types are returned in `data.custom_field_definitions`; keys in that map match keys under each opportunity's `custom_fields` object.",
         "requestBody": {
           "required": true,
-          "description": "Opportunity search body. `pipeline_id` is required.",
+          "description": "Opportunity search body. `pipeline_id` is optional; omit it to search across all pipelines.",
           "content": {
             "application/json": {
               "schema": {
@@ -4116,9 +4116,6 @@
       },
       "OpportunitySearchRequest": {
         "type": "object",
-        "required": [
-          "pipeline_id"
-        ],
         "properties": {
           "pipeline_id": {
             "type": "string"

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -5,6 +5,15 @@ description: "What's new in Octolane. Product updates, new features, improvement
 rss: true
 ---
 
+<Update label="June 27, 2026" description="API" tags={["Improvements"]}>
+  ### Search opportunities across all pipelines
+
+  `pipeline_id` is now optional on [`POST /v1/opportunities/search`](/api-reference/endpoints/crm/search-opportunities).
+
+  - Omit `pipeline_id` to search opportunities across every pipeline in the org
+  - Pass `pipeline_id` to scope the search to a single pipeline, as before
+</Update>
+
 <Update label="June 15, 2026" description="AI Chat" tags={["Improvements"]}>
   ### AI Chat: pinned conversations
 


### PR DESCRIPTION
## Summary
Updated the opportunities search endpoint to make `pipeline_id` optional, allowing users to search across all pipelines in an organization when the parameter is omitted.

## Changes
- **OpenAPI Schema**: Removed `pipeline_id` from the required fields list in `OpportunitySearchRequest`
- **API Documentation**: Updated endpoint descriptions to clarify that:
  - `pipeline_id` is now optional
  - Omitting it searches across all pipelines in the org
  - Passing it scopes the search to a single pipeline (existing behavior)
- **Changelog**: Added entry documenting this improvement

## Implementation Details
The change maintains backward compatibility—existing code that passes `pipeline_id` will continue to work as before. The optional nature of the parameter is now properly reflected in both the OpenAPI schema and user-facing documentation.

https://claude.ai/code/session_01AsvCSPESTHmi9bpPmxFbYX